### PR TITLE
Delete CODEOWNERS so to be in-line with `tern`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-*   @insightsengineering/nest-sme
-


### PR DESCRIPTION
Signed-off-by: Davide Garolini <dgarolini@gmail.com>