### PR TITLE
Remove lookup-refs

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -26,13 +26,6 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/random.cdisc.data
-        insightsengineering/rtables
-        insightsengineering/formatters
-        insightsengineering/tern
-        insightsengineering/rlistings
-        pharmaverse/pharmaverseadam
       additional-env-vars: |
         _R_CHECK_CRAN_INCOMING_REMOTE_=false
       additional-r-cmd-check-params: --as-cran ### We need to test snapshots, not released
@@ -54,13 +47,6 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/random.cdisc.data
-        insightsengineering/rtables
-        insightsengineering/formatters
-        insightsengineering/tern
-        insightsengineering/rlistings
-        pharmaverse/pharmaverseadam
       additional-env-vars: |
         NOT_CRAN=true
       enforce-note-blocklist: true
@@ -82,13 +68,6 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/random.cdisc.data
-        insightsengineering/rtables
-        insightsengineering/formatters
-        insightsengineering/tern
-        insightsengineering/rlistings
-        pharmaverse/pharmaverseadam
       additional-env-vars: |
         NOT_CRAN=true
   linter:
@@ -102,13 +81,6 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/random.cdisc.data
-        insightsengineering/rtables
-        insightsengineering/formatters
-        insightsengineering/tern
-        insightsengineering/rlistings
-        pharmaverse/pharmaverseadam
       auto-update: true
   gitleaks:
     name: gitleaks 💧

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -42,10 +42,3 @@ jobs:
     with:
       additional-unit-test-report-directories: unit-test-report-non-cran
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/random.cdisc.data
-        insightsengineering/rtables
-        insightsengineering/formatters
-        insightsengineering/tern
-        insightsengineering/rlistings
-        pharmaverse/pharmaverseadam


### PR DESCRIPTION
Part of https://github.com/insightsengineering/coredev-tasks/issues/609

From now on, we will provide development dependencies in 
```
Remotes: repo/project@branch
```
format, so it's explicitly visible in the DESCRIPTION file and can be handled by `pak::install`, `renv::install` and `remotes::install`.

With development dependencies specified in CJ Pipelines configuration, this connection was hidden, and it was hard to install the package from the main branch (or any other branch) locally from user's machine.