### PR TITLE
Updates after `pharmaverseadam` data updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Depends:
     rtables (>= 0.6.11.9017),
     tern (>= 0.9.7.9018)
 Imports:
-    pharmaverseadam (>= 1.1.0),
+    pharmaverseadam (>= 1.1.0.9001),
     random.cdisc.data (>= 0.3.16)
 Suggests:
     broom,

--- a/tests/testthat/_snaps/listing_egl01.md
+++ b/tests/testthat/_snaps/listing_egl01.md
@@ -7,7 +7,7 @@
       
       ——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
                                                                                           Heart Rate Result                    QT Duration Result                    RR Duration Result                 
-                                                                                  Study     (BEATS/MIN);        Heart Rate          (msec);          QT Duration          (msec);          RR Duration  
+                                                                                  Study     (beats/min);        Heart Rate           (ms);           QT Duration           (ms);           RR Duration  
       Treatment   Center/Subject ID            Age/Sex/Race             Visit      Day     Range:(40-100)     Change from BL    Range:(350-450)     Change from BL    Range:(600-1500)    Change from BL
       ——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
        Placebo        701/1015                  63/F/WHITE             Baseline     1            73.67                NA            456.67/H                NA            519.00/L                NA    

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -190,7 +190,8 @@ advs_raw <- random.cdisc.data::cadvs
 # Data loading for pharmaverse
 
 adpp_pharmaverse <- pharmaverseadam::adpp
-adpc_pharmaverse <- pharmaverseadam::adpc
+adpc_pharmaverse <- pharmaverseadam::adpc %>%
+  filter(!is.na(AVAL))
 
 set.seed(99)
 


### PR DESCRIPTION
Closes #193

----

**Summary of data changes (all from pharmaverseadam v1.1.0.9001):**

Change to ADPC:
- Split `24-48h Post-dose` records into two records identical except that one has `DTYPE = HALFLLOQ` and the other has `AVAL = NA`

Change to ADEG:
- Minor text changes to `EGSTRESU` (unit variable):
  - `BEATS/MIN` --> `beats/min`
  - `msec` --> `ms`