### PR TITLE
updated rtf snapshots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ Remotes:
     insightsengineering/rlistings@main,
     insightsengineering/rtables@main,
     insightsengineering/tern@main,
-    johnsonandjohnson/junco@dev,
+    johnsonandjohnson/junco@patch-release-updated-rtf-snapshots,
     johnsonandjohnson/pharmaverseadamjnj@main,
     johnsonandjohnson/pharmaversesdtmjnj@main,
     pharmaverse/pharmaverseadam@main

--- a/tests/testthat/_snaps/lsfecg01/lsfecg01.rtf
+++ b/tests/testthat/_snaps/lsfecg01/lsfecg01.rtf
@@ -64,7 +64,7 @@
 \pard\intbl\qc\fs16 01-701-1028 \cell
 \pard\intbl\qc\fs16 71 / M / Asian \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 38 N CS \cell
@@ -88,7 +88,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 195 N CS \cell
@@ -112,7 +112,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 285 N CS \cell
@@ -136,7 +136,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 499 N CS \cell
@@ -160,7 +160,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 343 N CS \cell
@@ -184,7 +184,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 309 N CS \cell
@@ -208,7 +208,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 458 N CS \cell
@@ -232,7 +232,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 19 N CS \cell
@@ -256,7 +256,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 194 N CS \cell
@@ -280,7 +280,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 370 H CS \cell
@@ -304,7 +304,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 363 H CS \cell
@@ -328,7 +328,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 98 H CS \cell
@@ -352,7 +352,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 196 N CS \cell
@@ -376,7 +376,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 333 H CS \cell
@@ -400,7 +400,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 149 H CS \cell
@@ -424,7 +424,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 201 H CS \cell
@@ -448,7 +448,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 530 H CS \cell
@@ -472,7 +472,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 596 H CS \cell
@@ -496,7 +496,7 @@
 \pard\intbl\qc\fs16 01-701-1034 \cell
 \pard\intbl\qc\fs16 77 / F / White \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 01JUL2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 01JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 257 N CS \cell
@@ -520,7 +520,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 15JUL2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 15JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 176 N CS \cell
@@ -544,7 +544,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29JUL2014 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 29JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 385 N CS \cell
@@ -568,7 +568,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11AUG2014 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 11AUG2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 140 N CS \cell
@@ -592,7 +592,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26AUG2014 / 06:00 (57) \cell
+\pard\intbl\qc\fs16 26AUG2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 23 N CS \cell
@@ -616,7 +616,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25SEP2014 / 06:00 (87) \cell
+\pard\intbl\qc\fs16 25SEP2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 465 N CS \cell
@@ -640,7 +640,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 21OCT2014 / 06:00 (113) \cell
+\pard\intbl\qc\fs16 21OCT2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 129 N CS \cell
@@ -664,7 +664,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 18NOV2014 / 06:00 (141) \cell
+\pard\intbl\qc\fs16 18NOV2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 164 N CS \cell
@@ -688,7 +688,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17DEC2014 / 06:00 (170) \cell
+\pard\intbl\qc\fs16 17DEC2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 587 N CS \cell
@@ -712,7 +712,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 01JUL2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 01JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 472 H CS \cell
@@ -736,7 +736,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 15JUL2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 15JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 68 H CS \cell
@@ -760,7 +760,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29JUL2014 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 29JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 168 H CS \cell
@@ -784,7 +784,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11AUG2014 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 11AUG2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 254 H CS \cell
@@ -808,7 +808,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26AUG2014 / 06:00 (57) \cell
+\pard\intbl\qc\fs16 26AUG2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 513 H CS \cell
@@ -832,7 +832,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25SEP2014 / 06:00 (87) \cell
+\pard\intbl\qc\fs16 25SEP2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 273 H CS \cell
@@ -856,7 +856,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 21OCT2014 / 06:00 (113) \cell
+\pard\intbl\qc\fs16 21OCT2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 137 H CS \cell
@@ -880,7 +880,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 18NOV2014 / 06:00 (141) \cell
+\pard\intbl\qc\fs16 18NOV2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 512 H CS \cell
@@ -904,7 +904,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17DEC2014 / 06:00 (170) \cell
+\pard\intbl\qc\fs16 17DEC2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 579 H CS \cell
@@ -928,7 +928,7 @@
 \pard\intbl\qc\fs16 01-701-1146 \cell
 \pard\intbl\qc\fs16 75 / F / Unknown \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 20MAY2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 20MAY2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 199 N CS \cell
@@ -952,7 +952,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 03JUN2013 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 03JUN2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 236 N CS \cell
@@ -976,7 +976,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 16JUN2013 / 06:00 (28) \cell
+\pard\intbl\qc\fs16 16JUN2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 257 N CS \cell
@@ -1000,7 +1000,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 30JUN2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 30JUN2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 379 N CS \cell
@@ -1024,7 +1024,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 20MAY2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 20MAY2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 52 H CS \cell
@@ -1048,7 +1048,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 03JUN2013 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 03JUN2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 499 H CS \cell
@@ -1072,7 +1072,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 16JUN2013 / 06:00 (28) \cell
+\pard\intbl\qc\fs16 16JUN2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 126 H CS \cell
@@ -1096,7 +1096,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 30JUN2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 30JUN2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 142 H CS \cell
@@ -1120,7 +1120,7 @@
 \pard\intbl\qc\fs16 01-701-1148 \cell
 \pard\intbl\qc\fs16 57 / M / Not reported \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 23AUG2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 23AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 420 N CS \cell
@@ -1144,7 +1144,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05SEP2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 05SEP2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 443 N CS \cell
@@ -1168,7 +1168,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 19SEP2013 / 06:00 (28) \cell
+\pard\intbl\qc\fs16 19SEP2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 28 N CS \cell
@@ -1192,7 +1192,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 03OCT2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 03OCT2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 240 N CS \cell
@@ -1216,7 +1216,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 18OCT2013 / 06:00 (57) \cell
+\pard\intbl\qc\fs16 18OCT2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 41 N CS \cell
@@ -1240,7 +1240,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17NOV2013 / 06:00 (87) \cell
+\pard\intbl\qc\fs16 17NOV2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 43 N CS \cell
@@ -1264,7 +1264,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2013 / 06:00 (113) \cell
+\pard\intbl\qc\fs16 13DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 223 N CS \cell
@@ -1288,7 +1288,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2014 / 06:00 (141) \cell
+\pard\intbl\qc\fs16 10JAN2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 7 N CS \cell
@@ -1312,7 +1312,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08FEB2014 / 06:00 (170) \cell
+\pard\intbl\qc\fs16 08FEB2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 550 N CS \cell
@@ -1336,7 +1336,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 23AUG2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 23AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 484 H CS \cell
@@ -1360,7 +1360,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05SEP2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 05SEP2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 217 H CS \cell
@@ -1384,7 +1384,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 19SEP2013 / 06:00 (28) \cell
+\pard\intbl\qc\fs16 19SEP2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 321 H CS \cell
@@ -1408,7 +1408,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 03OCT2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 03OCT2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 296 H CS \cell
@@ -1432,7 +1432,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 18OCT2013 / 06:00 (57) \cell
+\pard\intbl\qc\fs16 18OCT2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 360 H CS \cell
@@ -1456,7 +1456,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17NOV2013 / 06:00 (87) \cell
+\pard\intbl\qc\fs16 17NOV2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 89 H CS \cell
@@ -1480,7 +1480,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2013 / 06:00 (113) \cell
+\pard\intbl\qc\fs16 13DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 188 H CS \cell
@@ -1504,7 +1504,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2014 / 06:00 (141) \cell
+\pard\intbl\qc\fs16 10JAN2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 569 H CS \cell
@@ -1528,7 +1528,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08FEB2014 / 06:00 (170) \cell
+\pard\intbl\qc\fs16 08FEB2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 440 H CS \cell
@@ -1552,7 +1552,7 @@
 \pard\intbl\qc\fs16 01-701-1239 \cell
 \pard\intbl\qc\fs16 56 / M / White \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 11JAN2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 11JAN2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 379 N CS \cell
@@ -1576,7 +1576,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25JAN2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 25JAN2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 407 N CS \cell
@@ -1600,7 +1600,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08FEB2014 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 08FEB2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 134 N CS \cell
@@ -1624,7 +1624,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 19FEB2014 / 06:00 (40) \cell
+\pard\intbl\qc\fs16 19FEB2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 194 N CS \cell
@@ -1648,7 +1648,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06MAR2014 / 06:00 (55) \cell
+\pard\intbl\qc\fs16 06MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 206 N CS \cell
@@ -1672,7 +1672,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02APR2014 / 06:00 (82) \cell
+\pard\intbl\qc\fs16 02APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 474 N CS \cell
@@ -1696,7 +1696,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02MAY2014 / 06:00 (112) \cell
+\pard\intbl\qc\fs16 02MAY2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 279 N CS \cell
@@ -1720,7 +1720,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 28MAY2014 / 06:00 (138) \cell
+\pard\intbl\qc\fs16 28MAY2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 598 N CS \cell
@@ -1744,7 +1744,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27JUN2014 / 06:00 (168) \cell
+\pard\intbl\qc\fs16 27JUN2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 45 N CS \cell
@@ -1768,7 +1768,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 11JAN2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 11JAN2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 445 N CS \cell
@@ -1792,7 +1792,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25JAN2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 25JAN2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 358 H CS \cell
@@ -1816,7 +1816,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08FEB2014 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 08FEB2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 430 H CS \cell
@@ -1840,7 +1840,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 19FEB2014 / 06:00 (40) \cell
+\pard\intbl\qc\fs16 19FEB2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 582 H CS \cell
@@ -1864,7 +1864,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06MAR2014 / 06:00 (55) \cell
+\pard\intbl\qc\fs16 06MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 570 H CS \cell
@@ -1888,7 +1888,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02APR2014 / 06:00 (82) \cell
+\pard\intbl\qc\fs16 02APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 40 H CS \cell
@@ -1912,7 +1912,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02MAY2014 / 06:00 (112) \cell
+\pard\intbl\qc\fs16 02MAY2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 343 H CS \cell
@@ -1936,7 +1936,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 28MAY2014 / 06:00 (138) \cell
+\pard\intbl\qc\fs16 28MAY2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 142 H CS \cell
@@ -1960,7 +1960,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27JUN2014 / 06:00 (168) \cell
+\pard\intbl\qc\fs16 27JUN2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 0 H CS \cell
@@ -1984,7 +1984,7 @@
 \pard\intbl\qc\fs16 01-701-1275 \cell
 \pard\intbl\qc\fs16 61 / M / White \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 07FEB2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 07FEB2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 286 N CS \cell
@@ -2008,7 +2008,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 22FEB2014 / 06:00 (16) \cell
+\pard\intbl\qc\fs16 22FEB2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 50 N CS \cell
@@ -2032,7 +2032,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 07MAR2014 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 07MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 528 N CS \cell
@@ -2056,7 +2056,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 22MAR2014 / 06:00 (44) \cell
+\pard\intbl\qc\fs16 22MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 456 N CS \cell
@@ -2080,7 +2080,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05APR2014 / 06:00 (58) \cell
+\pard\intbl\qc\fs16 05APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 433 N CS \cell
@@ -2104,7 +2104,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 03MAY2014 / 06:00 (86) \cell
+\pard\intbl\qc\fs16 03MAY2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 328 N CS \cell
@@ -2128,7 +2128,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JUN2014 / 06:00 (128) \cell
+\pard\intbl\qc\fs16 14JUN2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 317 N CS \cell
@@ -2152,7 +2152,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 07FEB2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 07FEB2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 357 H CS \cell
@@ -2176,7 +2176,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 22FEB2014 / 06:00 (16) \cell
+\pard\intbl\qc\fs16 22FEB2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 538 H CS \cell
@@ -2200,7 +2200,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 07MAR2014 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 07MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 13 H CS \cell
@@ -2224,7 +2224,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 22MAR2014 / 06:00 (44) \cell
+\pard\intbl\qc\fs16 22MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 587 H CS \cell
@@ -2248,7 +2248,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05APR2014 / 06:00 (58) \cell
+\pard\intbl\qc\fs16 05APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 503 H CS \cell
@@ -2272,7 +2272,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 03MAY2014 / 06:00 (86) \cell
+\pard\intbl\qc\fs16 03MAY2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 256 H CS \cell
@@ -2296,7 +2296,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JUN2014 / 06:00 (128) \cell
+\pard\intbl\qc\fs16 14JUN2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 591 H CS \cell
@@ -2320,7 +2320,7 @@
 \pard\intbl\qc\fs16 01-701-1287 \cell
 \pard\intbl\qc\fs16 56 / F / Multiple \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 25JAN2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 25JAN2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 171 N CS \cell
@@ -2344,7 +2344,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11FEB2014 / 06:00 (18) \cell
+\pard\intbl\qc\fs16 11FEB2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 321 N CS \cell
@@ -2368,7 +2368,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 20FEB2014 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 20FEB2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 164 N CS \cell
@@ -2392,7 +2392,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06MAR2014 / 06:00 (41) \cell
+\pard\intbl\qc\fs16 06MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 274 N CS \cell
@@ -2416,7 +2416,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 21MAR2014 / 06:00 (56) \cell
+\pard\intbl\qc\fs16 21MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 76 N CS \cell
@@ -2440,7 +2440,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17APR2014 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 17APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 102 N CS \cell

--- a/tests/testthat/_snaps/lsfecg01/lsfecg01.rtf
+++ b/tests/testthat/_snaps/lsfecg01/lsfecg01.rtf
@@ -64,7 +64,7 @@
 \pard\intbl\qc\fs16 01-701-1028 \cell
 \pard\intbl\qc\fs16 71 / M / Asian \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 38 N CS \cell
@@ -88,7 +88,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 195 N CS \cell
@@ -112,7 +112,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 285 N CS \cell
@@ -136,7 +136,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 499 N CS \cell
@@ -160,7 +160,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 343 N CS \cell
@@ -184,7 +184,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 309 N CS \cell
@@ -208,7 +208,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 458 N CS \cell
@@ -232,7 +232,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 19 N CS \cell
@@ -256,7 +256,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 194 N CS \cell
@@ -280,7 +280,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 370 H CS \cell
@@ -304,7 +304,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 363 H CS \cell
@@ -328,7 +328,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 98 H CS \cell
@@ -352,7 +352,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 196 N CS \cell
@@ -376,7 +376,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 333 H CS \cell
@@ -400,7 +400,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 149 H CS \cell
@@ -424,7 +424,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 201 H CS \cell
@@ -448,7 +448,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 530 H CS \cell
@@ -472,7 +472,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 596 H CS \cell
@@ -496,7 +496,7 @@
 \pard\intbl\qc\fs16 01-701-1034 \cell
 \pard\intbl\qc\fs16 77 / F / White \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 01JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01JUL2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 257 N CS \cell
@@ -520,7 +520,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 15JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 15JUL2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 176 N CS \cell
@@ -544,7 +544,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 29JUL2014 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 385 N CS \cell
@@ -568,7 +568,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11AUG2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 11AUG2014 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 140 N CS \cell
@@ -592,7 +592,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26AUG2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 26AUG2014 / 06:00 (57) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 23 N CS \cell
@@ -616,7 +616,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25SEP2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 25SEP2014 / 06:00 (87) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 465 N CS \cell
@@ -640,7 +640,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 21OCT2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 21OCT2014 / 06:00 (113) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 129 N CS \cell
@@ -664,7 +664,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 18NOV2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 18NOV2014 / 06:00 (141) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 164 N CS \cell
@@ -688,7 +688,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17DEC2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 17DEC2014 / 06:00 (170) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 587 N CS \cell
@@ -712,7 +712,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 01JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01JUL2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 472 H CS \cell
@@ -736,7 +736,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 15JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 15JUL2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 68 H CS \cell
@@ -760,7 +760,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 29JUL2014 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 168 H CS \cell
@@ -784,7 +784,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11AUG2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 11AUG2014 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 254 H CS \cell
@@ -808,7 +808,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26AUG2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 26AUG2014 / 06:00 (57) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 513 H CS \cell
@@ -832,7 +832,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25SEP2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 25SEP2014 / 06:00 (87) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 273 H CS \cell
@@ -856,7 +856,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 21OCT2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 21OCT2014 / 06:00 (113) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 137 H CS \cell
@@ -880,7 +880,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 18NOV2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 18NOV2014 / 06:00 (141) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 512 H CS \cell
@@ -904,7 +904,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17DEC2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 17DEC2014 / 06:00 (170) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 579 H CS \cell
@@ -928,7 +928,7 @@
 \pard\intbl\qc\fs16 01-701-1146 \cell
 \pard\intbl\qc\fs16 75 / F / Unknown \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 20MAY2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 20MAY2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 199 N CS \cell
@@ -952,7 +952,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 03JUN2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 03JUN2013 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 236 N CS \cell
@@ -976,7 +976,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 16JUN2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 16JUN2013 / 06:00 (28) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 257 N CS \cell
@@ -1000,7 +1000,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 30JUN2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 30JUN2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 379 N CS \cell
@@ -1024,7 +1024,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 20MAY2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 20MAY2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 52 H CS \cell
@@ -1048,7 +1048,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 03JUN2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 03JUN2013 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 499 H CS \cell
@@ -1072,7 +1072,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 16JUN2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 16JUN2013 / 06:00 (28) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 126 H CS \cell
@@ -1096,7 +1096,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 30JUN2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 30JUN2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 142 H CS \cell
@@ -1120,7 +1120,7 @@
 \pard\intbl\qc\fs16 01-701-1148 \cell
 \pard\intbl\qc\fs16 57 / M / Not reported \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 23AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 23AUG2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 420 N CS \cell
@@ -1144,7 +1144,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05SEP2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 05SEP2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 443 N CS \cell
@@ -1168,7 +1168,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 19SEP2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 19SEP2013 / 06:00 (28) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 28 N CS \cell
@@ -1192,7 +1192,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 03OCT2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 03OCT2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 240 N CS \cell
@@ -1216,7 +1216,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 18OCT2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 18OCT2013 / 06:00 (57) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 41 N CS \cell
@@ -1240,7 +1240,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17NOV2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 17NOV2013 / 06:00 (87) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 43 N CS \cell
@@ -1264,7 +1264,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 13DEC2013 / 06:00 (113) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 223 N CS \cell
@@ -1288,7 +1288,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 10JAN2014 / 06:00 (141) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 7 N CS \cell
@@ -1312,7 +1312,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08FEB2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 08FEB2014 / 06:00 (170) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 550 N CS \cell
@@ -1336,7 +1336,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 23AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 23AUG2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 484 H CS \cell
@@ -1360,7 +1360,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05SEP2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 05SEP2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 217 H CS \cell
@@ -1384,7 +1384,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 19SEP2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 19SEP2013 / 06:00 (28) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 321 H CS \cell
@@ -1408,7 +1408,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 03OCT2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 03OCT2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 296 H CS \cell
@@ -1432,7 +1432,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 18OCT2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 18OCT2013 / 06:00 (57) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 360 H CS \cell
@@ -1456,7 +1456,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17NOV2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 17NOV2013 / 06:00 (87) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 89 H CS \cell
@@ -1480,7 +1480,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 13DEC2013 / 06:00 (113) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 188 H CS \cell
@@ -1504,7 +1504,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 10JAN2014 / 06:00 (141) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 569 H CS \cell
@@ -1528,7 +1528,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08FEB2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 08FEB2014 / 06:00 (170) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 440 H CS \cell
@@ -1552,7 +1552,7 @@
 \pard\intbl\qc\fs16 01-701-1239 \cell
 \pard\intbl\qc\fs16 56 / M / White \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 11JAN2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 11JAN2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 379 N CS \cell
@@ -1576,7 +1576,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25JAN2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 25JAN2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 407 N CS \cell
@@ -1600,7 +1600,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08FEB2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 08FEB2014 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 134 N CS \cell
@@ -1624,7 +1624,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 19FEB2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 19FEB2014 / 06:00 (40) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 194 N CS \cell
@@ -1648,7 +1648,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06MAR2014 / 06:00 (55) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 206 N CS \cell
@@ -1672,7 +1672,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 02APR2014 / 06:00 (82) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 474 N CS \cell
@@ -1696,7 +1696,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02MAY2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 02MAY2014 / 06:00 (112) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 279 N CS \cell
@@ -1720,7 +1720,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 28MAY2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 28MAY2014 / 06:00 (138) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 598 N CS \cell
@@ -1744,7 +1744,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27JUN2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 27JUN2014 / 06:00 (168) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 45 N CS \cell
@@ -1768,7 +1768,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 11JAN2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 11JAN2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 445 N CS \cell
@@ -1792,7 +1792,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25JAN2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 25JAN2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 358 H CS \cell
@@ -1816,7 +1816,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08FEB2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 08FEB2014 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 430 H CS \cell
@@ -1840,7 +1840,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 19FEB2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 19FEB2014 / 06:00 (40) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 582 H CS \cell
@@ -1864,7 +1864,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06MAR2014 / 06:00 (55) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 570 H CS \cell
@@ -1888,7 +1888,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 02APR2014 / 06:00 (82) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 40 H CS \cell
@@ -1912,7 +1912,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02MAY2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 02MAY2014 / 06:00 (112) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 343 H CS \cell
@@ -1936,7 +1936,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 28MAY2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 28MAY2014 / 06:00 (138) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 142 H CS \cell
@@ -1960,7 +1960,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27JUN2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 27JUN2014 / 06:00 (168) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 0 H CS \cell
@@ -1984,7 +1984,7 @@
 \pard\intbl\qc\fs16 01-701-1275 \cell
 \pard\intbl\qc\fs16 61 / M / White \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 07FEB2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 07FEB2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 286 N CS \cell
@@ -2008,7 +2008,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 22FEB2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 22FEB2014 / 06:00 (16) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 50 N CS \cell
@@ -2032,7 +2032,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 07MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 07MAR2014 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 528 N CS \cell
@@ -2056,7 +2056,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 22MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 22MAR2014 / 06:00 (44) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 456 N CS \cell
@@ -2080,7 +2080,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 05APR2014 / 06:00 (58) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 433 N CS \cell
@@ -2104,7 +2104,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 03MAY2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 03MAY2014 / 06:00 (86) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 328 N CS \cell
@@ -2128,7 +2128,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JUN2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 14JUN2014 / 06:00 (128) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 317 N CS \cell
@@ -2152,7 +2152,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 07FEB2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 07FEB2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 357 H CS \cell
@@ -2176,7 +2176,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 22FEB2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 22FEB2014 / 06:00 (16) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 538 H CS \cell
@@ -2200,7 +2200,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 07MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 07MAR2014 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 13 H CS \cell
@@ -2224,7 +2224,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 22MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 22MAR2014 / 06:00 (44) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 587 H CS \cell
@@ -2248,7 +2248,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 05APR2014 / 06:00 (58) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 503 H CS \cell
@@ -2272,7 +2272,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 03MAY2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 03MAY2014 / 06:00 (86) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 256 H CS \cell
@@ -2296,7 +2296,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JUN2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 14JUN2014 / 06:00 (128) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 591 H CS \cell
@@ -2320,7 +2320,7 @@
 \pard\intbl\qc\fs16 01-701-1287 \cell
 \pard\intbl\qc\fs16 56 / F / Multiple \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 25JAN2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 25JAN2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 171 N CS \cell
@@ -2344,7 +2344,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11FEB2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 11FEB2014 / 06:00 (18) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 321 N CS \cell
@@ -2368,7 +2368,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 20FEB2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 20FEB2014 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 164 N CS \cell
@@ -2392,7 +2392,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06MAR2014 / 06:00 (41) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 274 N CS \cell
@@ -2416,7 +2416,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 21MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 21MAR2014 / 06:00 (56) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 76 N CS \cell
@@ -2440,7 +2440,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 17APR2014 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 102 N CS \cell

--- a/tests/testthat/_snaps/lsfecg02part1/lsfecg02part1of3.rtf
+++ b/tests/testthat/_snaps/lsfecg02part1/lsfecg02part1of3.rtf
@@ -64,7 +64,7 @@
 \pard\intbl\qc\fs16 01-701-1033 \cell
 \pard\intbl\qc\fs16 74 / M / Multiple \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 18MAR2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 18MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 25 N NCS \cell
@@ -88,7 +88,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01APR2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 01APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 538 N CS \cell
@@ -112,7 +112,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14APR2014 / 06:00 (28) \cell
+\pard\intbl\qc\fs16 14APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 518 N CS \cell
@@ -136,7 +136,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Interpretation \cell
-\pard\intbl\qc\fs16 18MAR2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 18MAR2014 / 07:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -160,7 +160,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01APR2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 01APR2014 / 08:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -184,7 +184,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14APR2014 / 06:00 (28) \cell
+\pard\intbl\qc\fs16 14APR2014 / 08:00 (28) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -208,7 +208,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 18MAR2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 18MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 456 H CS \cell
@@ -232,7 +232,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01APR2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 01APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 197 H NCS \cell
@@ -256,7 +256,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14APR2014 / 06:00 (28) \cell
+\pard\intbl\qc\fs16 14APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 301 N CS \cell
@@ -280,7 +280,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QRS Duration, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 18MAR2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 18MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 507 N NCS \cell
@@ -304,7 +304,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01APR2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 01APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 350 N NCS \cell
@@ -328,7 +328,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14APR2014 / 06:00 (28) \cell
+\pard\intbl\qc\fs16 14APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 353 N NCS \cell
@@ -352,7 +352,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QT Interval, Corrected (msec) \cell
-\pard\intbl\qc\fs16 18MAR2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 18MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 347 H NCS \cell
@@ -376,7 +376,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01APR2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 01APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 494 H NCS \cell
@@ -400,7 +400,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14APR2014 / 06:00 (28) \cell
+\pard\intbl\qc\fs16 14APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 247 N NCS \cell
@@ -424,7 +424,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcB Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 18MAR2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 18MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 214 H NCS \cell
@@ -448,7 +448,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01APR2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 01APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 394 H NCS \cell
@@ -472,7 +472,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14APR2014 / 06:00 (28) \cell
+\pard\intbl\qc\fs16 14APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 329 H NCS \cell
@@ -496,7 +496,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcF Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 18MAR2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 18MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 503 H CS \cell
@@ -520,7 +520,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01APR2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 01APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 456 H NCS \cell
@@ -544,7 +544,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14APR2014 / 06:00 (28) \cell
+\pard\intbl\qc\fs16 14APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 411 H NCS \cell
@@ -568,7 +568,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 RR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 18MAR2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 18MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 567 L NCS \cell
@@ -592,7 +592,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01APR2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 01APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 376 L NCS \cell
@@ -616,7 +616,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14APR2014 / 06:00 (28) \cell
+\pard\intbl\qc\fs16 14APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 98 L NCS \cell
@@ -640,7 +640,7 @@
 \pard\intbl\qc\fs16 01-701-1111 \cell
 \pard\intbl\qc\fs16 81 / F / White \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 07SEP2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 07SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 417 N CS \cell
@@ -664,7 +664,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17SEP2012 / 06:00 (11) \cell
+\pard\intbl\qc\fs16 17SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 568 N CS \cell
@@ -688,7 +688,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Interpretation \cell
-\pard\intbl\qc\fs16 07SEP2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 07SEP2012 / 08:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -712,7 +712,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17SEP2012 / 06:00 (11) \cell
+\pard\intbl\qc\fs16 17SEP2012 / 08:00 (11) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -736,7 +736,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 07SEP2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 07SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 544 H CS \cell
@@ -760,7 +760,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17SEP2012 / 06:00 (11) \cell
+\pard\intbl\qc\fs16 17SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 222 H CS \cell
@@ -784,7 +784,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QRS Duration, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 07SEP2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 07SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 25 N NCS \cell
@@ -808,7 +808,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17SEP2012 / 06:00 (11) \cell
+\pard\intbl\qc\fs16 17SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 279 N NCS \cell
@@ -832,7 +832,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QT Interval, Corrected (msec) \cell
-\pard\intbl\qc\fs16 07SEP2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 07SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 405 H NCS \cell
@@ -856,7 +856,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17SEP2012 / 06:00 (11) \cell
+\pard\intbl\qc\fs16 17SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 238 H NCS \cell
@@ -880,7 +880,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcB Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 07SEP2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 07SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 459 H NCS \cell
@@ -904,7 +904,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17SEP2012 / 06:00 (11) \cell
+\pard\intbl\qc\fs16 17SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 220 H NCS \cell
@@ -928,7 +928,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcF Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 07SEP2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 07SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 247 H NCS \cell
@@ -952,7 +952,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17SEP2012 / 06:00 (11) \cell
+\pard\intbl\qc\fs16 17SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 460 H NCS \cell
@@ -976,7 +976,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 RR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 07SEP2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 07SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 77 L NCS \cell
@@ -1000,7 +1000,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17SEP2012 / 06:00 (11) \cell
+\pard\intbl\qc\fs16 17SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 535 L NCS \cell
@@ -1024,7 +1024,7 @@
 \pard\intbl\qc\fs16 01-701-1115 \cell
 \pard\intbl\qc\fs16 84 / M / Black or African American \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 30NOV2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 30NOV2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 423 N CS \cell
@@ -1048,7 +1048,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2012 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 13DEC2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 5 N NCS \cell
@@ -1072,7 +1072,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26DEC2012 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 26DEC2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 127 N CS \cell
@@ -1096,7 +1096,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 10JAN2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 48 N NCS \cell
@@ -1120,7 +1120,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23JAN2013 / 06:00 (55) \cell
+\pard\intbl\qc\fs16 23JAN2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 475 N CS \cell
@@ -1144,7 +1144,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Interpretation \cell
-\pard\intbl\qc\fs16 30NOV2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 30NOV2012 / 07:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL NCS \cell
@@ -1168,7 +1168,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2012 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 13DEC2012 / 07:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -1192,7 +1192,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26DEC2012 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 26DEC2012 / 07:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -1216,7 +1216,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 10JAN2013 / 07:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -1240,7 +1240,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23JAN2013 / 06:00 (55) \cell
+\pard\intbl\qc\fs16 23JAN2013 / 07:00 (55) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL NCS \cell
@@ -1264,7 +1264,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 30NOV2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 30NOV2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 105 H NCS \cell
@@ -1288,7 +1288,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2012 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 13DEC2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 61 H NCS \cell
@@ -1312,7 +1312,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26DEC2012 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 26DEC2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 151 H NCS \cell
@@ -1336,7 +1336,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 10JAN2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 92 H NCS \cell
@@ -1360,7 +1360,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23JAN2013 / 06:00 (55) \cell
+\pard\intbl\qc\fs16 23JAN2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 351 H CS \cell
@@ -1384,7 +1384,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QRS Duration, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 30NOV2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 30NOV2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 298 N NCS \cell
@@ -1408,7 +1408,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2012 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 13DEC2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 252 N NCS \cell
@@ -1432,7 +1432,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26DEC2012 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 26DEC2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 331 N NCS \cell
@@ -1456,7 +1456,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 10JAN2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 431 N NCS \cell
@@ -1480,7 +1480,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23JAN2013 / 06:00 (55) \cell
+\pard\intbl\qc\fs16 23JAN2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 544 N NCS \cell
@@ -1504,7 +1504,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QT Interval, Corrected (msec) \cell
-\pard\intbl\qc\fs16 30NOV2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 30NOV2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 398 H NCS \cell
@@ -1528,7 +1528,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2012 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 13DEC2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 322 H NCS \cell
@@ -1552,7 +1552,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26DEC2012 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 26DEC2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 485 H NCS \cell
@@ -1576,7 +1576,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 10JAN2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 497 N NCS \cell
@@ -1600,7 +1600,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23JAN2013 / 06:00 (55) \cell
+\pard\intbl\qc\fs16 23JAN2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 293 N NCS \cell
@@ -1624,7 +1624,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcB Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 30NOV2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 30NOV2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 467 H NCS \cell
@@ -1648,7 +1648,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2012 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 13DEC2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 422 H NCS \cell
@@ -1672,7 +1672,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26DEC2012 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 26DEC2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 457 H NCS \cell
@@ -1696,7 +1696,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 10JAN2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 260 H NCS \cell
@@ -1720,7 +1720,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23JAN2013 / 06:00 (55) \cell
+\pard\intbl\qc\fs16 23JAN2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 262 H NCS \cell
@@ -1744,7 +1744,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcF Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 30NOV2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 30NOV2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 360 H NCS \cell
@@ -1768,7 +1768,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2012 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 13DEC2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 215 H NCS \cell
@@ -1792,7 +1792,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26DEC2012 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 26DEC2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 236 H NCS \cell
@@ -1816,7 +1816,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 10JAN2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 457 H NCS \cell
@@ -1840,7 +1840,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23JAN2013 / 06:00 (55) \cell
+\pard\intbl\qc\fs16 23JAN2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 441 H NCS \cell
@@ -1864,7 +1864,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 RR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 30NOV2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 30NOV2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 526 L NCS \cell
@@ -1888,7 +1888,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2012 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 13DEC2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 528 L NCS \cell
@@ -1912,7 +1912,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26DEC2012 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 26DEC2012 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 355 L NCS \cell
@@ -1936,7 +1936,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 10JAN2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 418 L NCS \cell
@@ -1960,7 +1960,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23JAN2013 / 06:00 (55) \cell
+\pard\intbl\qc\fs16 23JAN2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 13 N NCS \cell
@@ -1984,7 +1984,7 @@
 \pard\intbl\qc\fs16 01-701-1181 \cell
 \pard\intbl\qc\fs16 79 / F / Not reported \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 05DEC2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 05DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 25 N NCS \cell
@@ -2008,7 +2008,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 12DEC2013 / 06:00 (8) \cell
+\pard\intbl\qc\fs16 12DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 45 N NCS \cell
@@ -2032,7 +2032,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Interpretation \cell
-\pard\intbl\qc\fs16 05DEC2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 05DEC2013 / 07:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -2056,7 +2056,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 12DEC2013 / 06:00 (8) \cell
+\pard\intbl\qc\fs16 12DEC2013 / 07:00 (8) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -2080,7 +2080,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05DEC2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 05DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 390 H CS \cell
@@ -2104,7 +2104,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 12DEC2013 / 06:00 (8) \cell
+\pard\intbl\qc\fs16 12DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 280 H CS \cell
@@ -2128,7 +2128,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QRS Duration, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05DEC2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 05DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 278 N NCS \cell
@@ -2152,7 +2152,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 12DEC2013 / 06:00 (8) \cell
+\pard\intbl\qc\fs16 12DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 123 N NCS \cell
@@ -2176,7 +2176,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QT Interval, Corrected (msec) \cell
-\pard\intbl\qc\fs16 05DEC2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 05DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 385 H NCS \cell
@@ -2200,7 +2200,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 12DEC2013 / 06:00 (8) \cell
+\pard\intbl\qc\fs16 12DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 279 N NCS \cell
@@ -2224,7 +2224,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcB Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05DEC2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 05DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 249 H NCS \cell
@@ -2248,7 +2248,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 12DEC2013 / 06:00 (8) \cell
+\pard\intbl\qc\fs16 12DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 323 H NCS \cell
@@ -2272,7 +2272,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcF Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05DEC2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 05DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 251 H NCS \cell
@@ -2296,7 +2296,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 12DEC2013 / 06:00 (8) \cell
+\pard\intbl\qc\fs16 12DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 290 H NCS \cell
@@ -2320,7 +2320,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 RR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05DEC2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 05DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 326 L NCS \cell
@@ -2344,7 +2344,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 12DEC2013 / 06:00 (8) \cell
+\pard\intbl\qc\fs16 12DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 390 L NCS \cell
@@ -2368,7 +2368,7 @@
 \pard\intbl\qc\fs16 01-701-1188 \cell
 \pard\intbl\qc\fs16 71 / M / White \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 15FEB2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 15FEB2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 583 N CS \cell
@@ -2392,7 +2392,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02MAR2013 / 06:00 (16) \cell
+\pard\intbl\qc\fs16 02MAR2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 201 N CS \cell
@@ -2416,7 +2416,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 16MAR2013 / 06:00 (30) \cell
+\pard\intbl\qc\fs16 16MAR2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 347 N CS \cell
@@ -2440,7 +2440,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25MAR2013 / 06:00 (39) \cell
+\pard\intbl\qc\fs16 25MAR2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 548 N CS \cell

--- a/tests/testthat/_snaps/lsfecg02part1/lsfecg02part1of3.rtf
+++ b/tests/testthat/_snaps/lsfecg02part1/lsfecg02part1of3.rtf
@@ -64,7 +64,7 @@
 \pard\intbl\qc\fs16 01-701-1033 \cell
 \pard\intbl\qc\fs16 74 / M / Multiple \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 18MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 18MAR2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 25 N NCS \cell
@@ -88,7 +88,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01APR2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 538 N CS \cell
@@ -112,7 +112,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 14APR2014 / 06:00 (28) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 518 N CS \cell
@@ -136,7 +136,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Interpretation \cell
-\pard\intbl\qc\fs16 18MAR2014 / 07:00 (1) \cell
+\pard\intbl\qc\fs16 18MAR2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -160,7 +160,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01APR2014 / 08:00 (15) \cell
+\pard\intbl\qc\fs16 01APR2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -184,7 +184,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14APR2014 / 08:00 (28) \cell
+\pard\intbl\qc\fs16 14APR2014 / 06:00 (28) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -208,7 +208,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 18MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 18MAR2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 456 H CS \cell
@@ -232,7 +232,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01APR2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 197 H NCS \cell
@@ -256,7 +256,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 14APR2014 / 06:00 (28) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 301 N CS \cell
@@ -280,7 +280,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QRS Duration, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 18MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 18MAR2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 507 N NCS \cell
@@ -304,7 +304,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01APR2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 350 N NCS \cell
@@ -328,7 +328,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 14APR2014 / 06:00 (28) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 353 N NCS \cell
@@ -352,7 +352,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QT Interval, Corrected (msec) \cell
-\pard\intbl\qc\fs16 18MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 18MAR2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 347 H NCS \cell
@@ -376,7 +376,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01APR2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 494 H NCS \cell
@@ -400,7 +400,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 14APR2014 / 06:00 (28) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 247 N NCS \cell
@@ -424,7 +424,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcB Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 18MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 18MAR2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 214 H NCS \cell
@@ -448,7 +448,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01APR2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 394 H NCS \cell
@@ -472,7 +472,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 14APR2014 / 06:00 (28) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 329 H NCS \cell
@@ -496,7 +496,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcF Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 18MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 18MAR2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 503 H CS \cell
@@ -520,7 +520,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01APR2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 456 H NCS \cell
@@ -544,7 +544,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 14APR2014 / 06:00 (28) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 411 H NCS \cell
@@ -568,7 +568,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 RR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 18MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 18MAR2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 567 L NCS \cell
@@ -592,7 +592,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01APR2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 376 L NCS \cell
@@ -616,7 +616,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 14APR2014 / 06:00 (28) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 98 L NCS \cell
@@ -640,7 +640,7 @@
 \pard\intbl\qc\fs16 01-701-1111 \cell
 \pard\intbl\qc\fs16 81 / F / White \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 07SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 07SEP2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 417 N CS \cell
@@ -664,7 +664,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 17SEP2012 / 06:00 (11) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 568 N CS \cell
@@ -688,7 +688,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Interpretation \cell
-\pard\intbl\qc\fs16 07SEP2012 / 08:00 (1) \cell
+\pard\intbl\qc\fs16 07SEP2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -712,7 +712,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17SEP2012 / 08:00 (11) \cell
+\pard\intbl\qc\fs16 17SEP2012 / 06:00 (11) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -736,7 +736,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 07SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 07SEP2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 544 H CS \cell
@@ -760,7 +760,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 17SEP2012 / 06:00 (11) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 222 H CS \cell
@@ -784,7 +784,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QRS Duration, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 07SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 07SEP2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 25 N NCS \cell
@@ -808,7 +808,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 17SEP2012 / 06:00 (11) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 279 N NCS \cell
@@ -832,7 +832,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QT Interval, Corrected (msec) \cell
-\pard\intbl\qc\fs16 07SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 07SEP2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 405 H NCS \cell
@@ -856,7 +856,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 17SEP2012 / 06:00 (11) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 238 H NCS \cell
@@ -880,7 +880,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcB Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 07SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 07SEP2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 459 H NCS \cell
@@ -904,7 +904,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 17SEP2012 / 06:00 (11) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 220 H NCS \cell
@@ -928,7 +928,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcF Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 07SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 07SEP2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 247 H NCS \cell
@@ -952,7 +952,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 17SEP2012 / 06:00 (11) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 460 H NCS \cell
@@ -976,7 +976,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 RR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 07SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 07SEP2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 77 L NCS \cell
@@ -1000,7 +1000,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 17SEP2012 / 06:00 (11) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 535 L NCS \cell
@@ -1024,7 +1024,7 @@
 \pard\intbl\qc\fs16 01-701-1115 \cell
 \pard\intbl\qc\fs16 84 / M / Black or African American \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 30NOV2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 30NOV2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 423 N CS \cell
@@ -1048,7 +1048,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 13DEC2012 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 5 N NCS \cell
@@ -1072,7 +1072,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26DEC2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 26DEC2012 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 127 N CS \cell
@@ -1096,7 +1096,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 10JAN2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 48 N NCS \cell
@@ -1120,7 +1120,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23JAN2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 23JAN2013 / 06:00 (55) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 475 N CS \cell
@@ -1144,7 +1144,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Interpretation \cell
-\pard\intbl\qc\fs16 30NOV2012 / 07:00 (1) \cell
+\pard\intbl\qc\fs16 30NOV2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL NCS \cell
@@ -1168,7 +1168,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2012 / 07:00 (14) \cell
+\pard\intbl\qc\fs16 13DEC2012 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -1192,7 +1192,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26DEC2012 / 07:00 (27) \cell
+\pard\intbl\qc\fs16 26DEC2012 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -1216,7 +1216,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2013 / 07:00 (42) \cell
+\pard\intbl\qc\fs16 10JAN2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -1240,7 +1240,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23JAN2013 / 07:00 (55) \cell
+\pard\intbl\qc\fs16 23JAN2013 / 06:00 (55) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL NCS \cell
@@ -1264,7 +1264,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 30NOV2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 30NOV2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 105 H NCS \cell
@@ -1288,7 +1288,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 13DEC2012 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 61 H NCS \cell
@@ -1312,7 +1312,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26DEC2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 26DEC2012 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 151 H NCS \cell
@@ -1336,7 +1336,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 10JAN2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 92 H NCS \cell
@@ -1360,7 +1360,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23JAN2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 23JAN2013 / 06:00 (55) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 351 H CS \cell
@@ -1384,7 +1384,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QRS Duration, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 30NOV2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 30NOV2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 298 N NCS \cell
@@ -1408,7 +1408,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 13DEC2012 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 252 N NCS \cell
@@ -1432,7 +1432,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26DEC2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 26DEC2012 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 331 N NCS \cell
@@ -1456,7 +1456,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 10JAN2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 431 N NCS \cell
@@ -1480,7 +1480,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23JAN2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 23JAN2013 / 06:00 (55) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 544 N NCS \cell
@@ -1504,7 +1504,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QT Interval, Corrected (msec) \cell
-\pard\intbl\qc\fs16 30NOV2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 30NOV2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 398 H NCS \cell
@@ -1528,7 +1528,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 13DEC2012 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 322 H NCS \cell
@@ -1552,7 +1552,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26DEC2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 26DEC2012 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 485 H NCS \cell
@@ -1576,7 +1576,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 10JAN2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 497 N NCS \cell
@@ -1600,7 +1600,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23JAN2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 23JAN2013 / 06:00 (55) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 293 N NCS \cell
@@ -1624,7 +1624,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcB Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 30NOV2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 30NOV2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 467 H NCS \cell
@@ -1648,7 +1648,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 13DEC2012 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 422 H NCS \cell
@@ -1672,7 +1672,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26DEC2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 26DEC2012 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 457 H NCS \cell
@@ -1696,7 +1696,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 10JAN2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 260 H NCS \cell
@@ -1720,7 +1720,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23JAN2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 23JAN2013 / 06:00 (55) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 262 H NCS \cell
@@ -1744,7 +1744,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcF Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 30NOV2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 30NOV2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 360 H NCS \cell
@@ -1768,7 +1768,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 13DEC2012 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 215 H NCS \cell
@@ -1792,7 +1792,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26DEC2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 26DEC2012 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 236 H NCS \cell
@@ -1816,7 +1816,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 10JAN2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 457 H NCS \cell
@@ -1840,7 +1840,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23JAN2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 23JAN2013 / 06:00 (55) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 441 H NCS \cell
@@ -1864,7 +1864,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 RR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 30NOV2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 30NOV2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 526 L NCS \cell
@@ -1888,7 +1888,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 13DEC2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 13DEC2012 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 528 L NCS \cell
@@ -1912,7 +1912,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26DEC2012 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 26DEC2012 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 355 L NCS \cell
@@ -1936,7 +1936,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10JAN2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 10JAN2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 418 L NCS \cell
@@ -1960,7 +1960,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23JAN2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 23JAN2013 / 06:00 (55) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 13 N NCS \cell
@@ -1984,7 +1984,7 @@
 \pard\intbl\qc\fs16 01-701-1181 \cell
 \pard\intbl\qc\fs16 79 / F / Not reported \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 05DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 05DEC2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 25 N NCS \cell
@@ -2008,7 +2008,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 12DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12DEC2013 / 06:00 (8) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 45 N NCS \cell
@@ -2032,7 +2032,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Interpretation \cell
-\pard\intbl\qc\fs16 05DEC2013 / 07:00 (1) \cell
+\pard\intbl\qc\fs16 05DEC2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -2056,7 +2056,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 12DEC2013 / 07:00 (8) \cell
+\pard\intbl\qc\fs16 12DEC2013 / 06:00 (8) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -2080,7 +2080,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 05DEC2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 390 H CS \cell
@@ -2104,7 +2104,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 12DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12DEC2013 / 06:00 (8) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 280 H CS \cell
@@ -2128,7 +2128,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QRS Duration, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 05DEC2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 278 N NCS \cell
@@ -2152,7 +2152,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 12DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12DEC2013 / 06:00 (8) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 123 N NCS \cell
@@ -2176,7 +2176,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QT Interval, Corrected (msec) \cell
-\pard\intbl\qc\fs16 05DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 05DEC2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 385 H NCS \cell
@@ -2200,7 +2200,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 12DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12DEC2013 / 06:00 (8) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 279 N NCS \cell
@@ -2224,7 +2224,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcB Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 05DEC2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 249 H NCS \cell
@@ -2248,7 +2248,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 12DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12DEC2013 / 06:00 (8) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 323 H NCS \cell
@@ -2272,7 +2272,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcF Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 05DEC2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 251 H NCS \cell
@@ -2296,7 +2296,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 12DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12DEC2013 / 06:00 (8) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 290 H NCS \cell
@@ -2320,7 +2320,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 RR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 05DEC2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 326 L NCS \cell
@@ -2344,7 +2344,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 12DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12DEC2013 / 06:00 (8) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 390 L NCS \cell
@@ -2368,7 +2368,7 @@
 \pard\intbl\qc\fs16 01-701-1188 \cell
 \pard\intbl\qc\fs16 71 / M / White \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 15FEB2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 15FEB2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 583 N CS \cell
@@ -2392,7 +2392,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02MAR2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 02MAR2013 / 06:00 (16) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 201 N CS \cell
@@ -2416,7 +2416,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 16MAR2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 16MAR2013 / 06:00 (30) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 347 N CS \cell
@@ -2440,7 +2440,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25MAR2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 25MAR2013 / 06:00 (39) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 548 N CS \cell

--- a/tests/testthat/_snaps/lsfecg02part2/lsfecg02part2of3.rtf
+++ b/tests/testthat/_snaps/lsfecg02part2/lsfecg02part2of3.rtf
@@ -64,7 +64,7 @@
 \pard\intbl\qc\fs16 01-701-1028 \cell
 \pard\intbl\qc\fs16 71 / M / Asian \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 38 N NCS \cell
@@ -88,7 +88,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 195 N CS \cell
@@ -112,7 +112,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 285 N CS \cell
@@ -136,7 +136,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 499 N CS \cell
@@ -160,7 +160,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 343 N CS \cell
@@ -184,7 +184,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 309 N CS \cell
@@ -208,7 +208,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 458 N CS \cell
@@ -232,7 +232,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 19 N NCS \cell
@@ -256,7 +256,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 194 N CS \cell
@@ -280,7 +280,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Interpretation \cell
-\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 08:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -304,7 +304,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 08:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -328,7 +328,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 08:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -352,7 +352,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -376,7 +376,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 08:00 (54) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -400,7 +400,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 08:00 (83) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -424,7 +424,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 07:00 (111) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -448,7 +448,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -472,7 +472,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -496,7 +496,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 370 H CS \cell
@@ -520,7 +520,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 363 H CS \cell
@@ -544,7 +544,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 98 H NCS \cell
@@ -568,7 +568,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 196 N NCS \cell
@@ -592,7 +592,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 333 H CS \cell
@@ -616,7 +616,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 149 H NCS \cell
@@ -640,7 +640,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 201 H CS \cell
@@ -664,7 +664,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 530 H CS \cell
@@ -688,7 +688,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 596 H CS \cell
@@ -712,7 +712,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QRS Duration, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 241 N NCS \cell
@@ -736,7 +736,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 179 N NCS \cell
@@ -760,7 +760,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 520 N NCS \cell
@@ -784,7 +784,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 419 N NCS \cell
@@ -808,7 +808,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 493 N NCS \cell
@@ -832,7 +832,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 141 N NCS \cell
@@ -856,7 +856,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 266 N NCS \cell
@@ -880,7 +880,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 184 N NCS \cell
@@ -904,7 +904,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 592 N NCS \cell
@@ -928,7 +928,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QT Interval, Corrected (msec) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 230 H NCS \cell
@@ -952,7 +952,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 278 H NCS \cell
@@ -976,7 +976,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 241 N NCS \cell
@@ -1000,7 +1000,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 215 L NCS \cell
@@ -1024,7 +1024,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 337 H NCS \cell
@@ -1048,7 +1048,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 508 H CS \cell
@@ -1072,7 +1072,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 402 H NCS \cell
@@ -1096,7 +1096,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 332 H NCS \cell
@@ -1120,7 +1120,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 440 H NCS \cell
@@ -1144,7 +1144,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcB Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 319 H NCS \cell
@@ -1168,7 +1168,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 367 H NCS \cell
@@ -1192,7 +1192,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 473 H NCS \cell
@@ -1216,7 +1216,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 423 H NCS \cell
@@ -1240,7 +1240,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 336 H NCS \cell
@@ -1264,7 +1264,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 393 H NCS \cell
@@ -1288,7 +1288,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 287 H NCS \cell
@@ -1312,7 +1312,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 374 H NCS \cell
@@ -1336,7 +1336,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 348 H NCS \cell
@@ -1360,7 +1360,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcF Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 379 H NCS \cell
@@ -1384,7 +1384,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 356 H NCS \cell
@@ -1408,7 +1408,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 452 H NCS \cell
@@ -1432,7 +1432,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 300 N NCS \cell
@@ -1456,7 +1456,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 303 H NCS \cell
@@ -1480,7 +1480,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 269 H NCS \cell
@@ -1504,7 +1504,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 352 H NCS \cell
@@ -1528,7 +1528,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 261 H NCS \cell
@@ -1552,7 +1552,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 348 H NCS \cell
@@ -1576,7 +1576,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 RR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 53 L NCS \cell
@@ -1600,7 +1600,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 476 L NCS \cell
@@ -1624,7 +1624,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 498 L NCS \cell
@@ -1648,7 +1648,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 212 L NCS \cell
@@ -1672,7 +1672,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 469 L NCS \cell
@@ -1696,7 +1696,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 419 L NCS \cell
@@ -1720,7 +1720,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 54 L NCS \cell
@@ -1744,7 +1744,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 479 L NCS \cell
@@ -1768,7 +1768,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 137 L NCS \cell
@@ -1792,7 +1792,7 @@
 \pard\intbl\qc\fs16 01-701-1034 \cell
 \pard\intbl\qc\fs16 77 / F / White \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 01JUL2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 01JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 257 N CS \cell
@@ -1816,7 +1816,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 15JUL2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 15JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 176 N CS \cell
@@ -1840,7 +1840,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29JUL2014 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 29JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 385 N CS \cell
@@ -1864,7 +1864,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11AUG2014 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 11AUG2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 140 N CS \cell
@@ -1888,7 +1888,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26AUG2014 / 06:00 (57) \cell
+\pard\intbl\qc\fs16 26AUG2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 23 N NCS \cell
@@ -1912,7 +1912,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25SEP2014 / 06:00 (87) \cell
+\pard\intbl\qc\fs16 25SEP2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 465 N CS \cell
@@ -1936,7 +1936,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 21OCT2014 / 06:00 (113) \cell
+\pard\intbl\qc\fs16 21OCT2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 129 N CS \cell
@@ -1960,7 +1960,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 18NOV2014 / 06:00 (141) \cell
+\pard\intbl\qc\fs16 18NOV2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 164 N CS \cell
@@ -1984,7 +1984,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17DEC2014 / 06:00 (170) \cell
+\pard\intbl\qc\fs16 17DEC2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 587 N CS \cell
@@ -2008,7 +2008,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Interpretation \cell
-\pard\intbl\qc\fs16 01JUL2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 01JUL2014 / 08:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -2032,7 +2032,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 15JUL2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 15JUL2014 / 08:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -2056,7 +2056,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29JUL2014 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 29JUL2014 / 08:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL NCS \cell
@@ -2080,7 +2080,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11AUG2014 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 11AUG2014 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL NCS \cell
@@ -2104,7 +2104,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26AUG2014 / 06:00 (57) \cell
+\pard\intbl\qc\fs16 26AUG2014 / 08:00 (57) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -2128,7 +2128,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25SEP2014 / 06:00 (87) \cell
+\pard\intbl\qc\fs16 25SEP2014 / 08:00 (87) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -2152,7 +2152,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 21OCT2014 / 06:00 (113) \cell
+\pard\intbl\qc\fs16 21OCT2014 / 08:00 (113) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -2176,7 +2176,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 18NOV2014 / 06:00 (141) \cell
+\pard\intbl\qc\fs16 18NOV2014 / 07:00 (141) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -2200,7 +2200,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17DEC2014 / 06:00 (170) \cell
+\pard\intbl\qc\fs16 17DEC2014 / 07:00 (170) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL NCS \cell
@@ -2224,7 +2224,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 01JUL2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 01JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 472 H CS \cell
@@ -2248,7 +2248,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 15JUL2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 15JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 68 H NCS \cell
@@ -2272,7 +2272,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29JUL2014 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 29JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 168 H NCS \cell
@@ -2296,7 +2296,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11AUG2014 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 11AUG2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 254 H CS \cell
@@ -2320,7 +2320,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26AUG2014 / 06:00 (57) \cell
+\pard\intbl\qc\fs16 26AUG2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 513 H CS \cell
@@ -2344,7 +2344,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25SEP2014 / 06:00 (87) \cell
+\pard\intbl\qc\fs16 25SEP2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 273 H CS \cell
@@ -2368,7 +2368,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 21OCT2014 / 06:00 (113) \cell
+\pard\intbl\qc\fs16 21OCT2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 137 H NCS \cell
@@ -2392,7 +2392,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 18NOV2014 / 06:00 (141) \cell
+\pard\intbl\qc\fs16 18NOV2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 512 H CS \cell
@@ -2416,7 +2416,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17DEC2014 / 06:00 (170) \cell
+\pard\intbl\qc\fs16 17DEC2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 579 H CS \cell
@@ -2440,7 +2440,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QRS Duration, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 01JUL2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 01JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 406 N NCS \cell

--- a/tests/testthat/_snaps/lsfecg02part2/lsfecg02part2of3.rtf
+++ b/tests/testthat/_snaps/lsfecg02part2/lsfecg02part2of3.rtf
@@ -64,7 +64,7 @@
 \pard\intbl\qc\fs16 01-701-1028 \cell
 \pard\intbl\qc\fs16 71 / M / Asian \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 38 N NCS \cell
@@ -88,7 +88,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 195 N CS \cell
@@ -112,7 +112,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 285 N CS \cell
@@ -136,7 +136,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 499 N CS \cell
@@ -160,7 +160,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 343 N CS \cell
@@ -184,7 +184,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 309 N CS \cell
@@ -208,7 +208,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 458 N CS \cell
@@ -232,7 +232,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 19 N NCS \cell
@@ -256,7 +256,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 194 N CS \cell
@@ -280,7 +280,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Interpretation \cell
-\pard\intbl\qc\fs16 19JUL2013 / 08:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -304,7 +304,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 08:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -328,7 +328,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 08:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -352,7 +352,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -376,7 +376,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 08:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -400,7 +400,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 08:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -424,7 +424,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 07:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -448,7 +448,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -472,7 +472,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -496,7 +496,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 370 H CS \cell
@@ -520,7 +520,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 363 H CS \cell
@@ -544,7 +544,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 98 H NCS \cell
@@ -568,7 +568,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 196 N NCS \cell
@@ -592,7 +592,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 333 H CS \cell
@@ -616,7 +616,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 149 H NCS \cell
@@ -640,7 +640,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 201 H CS \cell
@@ -664,7 +664,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 530 H CS \cell
@@ -688,7 +688,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 596 H CS \cell
@@ -712,7 +712,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QRS Duration, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 241 N NCS \cell
@@ -736,7 +736,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 179 N NCS \cell
@@ -760,7 +760,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 520 N NCS \cell
@@ -784,7 +784,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 419 N NCS \cell
@@ -808,7 +808,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 493 N NCS \cell
@@ -832,7 +832,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 141 N NCS \cell
@@ -856,7 +856,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 266 N NCS \cell
@@ -880,7 +880,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 184 N NCS \cell
@@ -904,7 +904,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 592 N NCS \cell
@@ -928,7 +928,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QT Interval, Corrected (msec) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 230 H NCS \cell
@@ -952,7 +952,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 278 H NCS \cell
@@ -976,7 +976,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 241 N NCS \cell
@@ -1000,7 +1000,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 215 L NCS \cell
@@ -1024,7 +1024,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 337 H NCS \cell
@@ -1048,7 +1048,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 508 H CS \cell
@@ -1072,7 +1072,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 402 H NCS \cell
@@ -1096,7 +1096,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 332 H NCS \cell
@@ -1120,7 +1120,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 440 H NCS \cell
@@ -1144,7 +1144,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcB Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 319 H NCS \cell
@@ -1168,7 +1168,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 367 H NCS \cell
@@ -1192,7 +1192,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 473 H NCS \cell
@@ -1216,7 +1216,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 423 H NCS \cell
@@ -1240,7 +1240,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 336 H NCS \cell
@@ -1264,7 +1264,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 393 H NCS \cell
@@ -1288,7 +1288,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 287 H NCS \cell
@@ -1312,7 +1312,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 374 H NCS \cell
@@ -1336,7 +1336,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 348 H NCS \cell
@@ -1360,7 +1360,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcF Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 379 H NCS \cell
@@ -1384,7 +1384,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 356 H NCS \cell
@@ -1408,7 +1408,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 452 H NCS \cell
@@ -1432,7 +1432,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 300 N NCS \cell
@@ -1456,7 +1456,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 303 H NCS \cell
@@ -1480,7 +1480,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 269 H NCS \cell
@@ -1504,7 +1504,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 352 H NCS \cell
@@ -1528,7 +1528,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 261 H NCS \cell
@@ -1552,7 +1552,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 348 H NCS \cell
@@ -1576,7 +1576,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 RR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 53 L NCS \cell
@@ -1600,7 +1600,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 476 L NCS \cell
@@ -1624,7 +1624,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 498 L NCS \cell
@@ -1648,7 +1648,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 212 L NCS \cell
@@ -1672,7 +1672,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 469 L NCS \cell
@@ -1696,7 +1696,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 419 L NCS \cell
@@ -1720,7 +1720,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 54 L NCS \cell
@@ -1744,7 +1744,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 479 L NCS \cell
@@ -1768,7 +1768,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 137 L NCS \cell
@@ -1792,7 +1792,7 @@
 \pard\intbl\qc\fs16 01-701-1034 \cell
 \pard\intbl\qc\fs16 77 / F / White \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 01JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01JUL2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 257 N CS \cell
@@ -1816,7 +1816,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 15JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 15JUL2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 176 N CS \cell
@@ -1840,7 +1840,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 29JUL2014 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 385 N CS \cell
@@ -1864,7 +1864,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11AUG2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 11AUG2014 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 140 N CS \cell
@@ -1888,7 +1888,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26AUG2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 26AUG2014 / 06:00 (57) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 23 N NCS \cell
@@ -1912,7 +1912,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25SEP2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 25SEP2014 / 06:00 (87) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 465 N CS \cell
@@ -1936,7 +1936,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 21OCT2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 21OCT2014 / 06:00 (113) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 129 N CS \cell
@@ -1960,7 +1960,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 18NOV2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 18NOV2014 / 06:00 (141) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 164 N CS \cell
@@ -1984,7 +1984,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17DEC2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 17DEC2014 / 06:00 (170) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 587 N CS \cell
@@ -2008,7 +2008,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Interpretation \cell
-\pard\intbl\qc\fs16 01JUL2014 / 08:00 (1) \cell
+\pard\intbl\qc\fs16 01JUL2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -2032,7 +2032,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 15JUL2014 / 08:00 (15) \cell
+\pard\intbl\qc\fs16 15JUL2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -2056,7 +2056,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29JUL2014 / 08:00 (29) \cell
+\pard\intbl\qc\fs16 29JUL2014 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL NCS \cell
@@ -2080,7 +2080,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11AUG2014 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 11AUG2014 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL NCS \cell
@@ -2104,7 +2104,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26AUG2014 / 08:00 (57) \cell
+\pard\intbl\qc\fs16 26AUG2014 / 06:00 (57) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -2128,7 +2128,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25SEP2014 / 08:00 (87) \cell
+\pard\intbl\qc\fs16 25SEP2014 / 06:00 (87) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -2152,7 +2152,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 21OCT2014 / 08:00 (113) \cell
+\pard\intbl\qc\fs16 21OCT2014 / 06:00 (113) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -2176,7 +2176,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 18NOV2014 / 07:00 (141) \cell
+\pard\intbl\qc\fs16 18NOV2014 / 06:00 (141) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -2200,7 +2200,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17DEC2014 / 07:00 (170) \cell
+\pard\intbl\qc\fs16 17DEC2014 / 06:00 (170) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL NCS \cell
@@ -2224,7 +2224,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 01JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01JUL2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 472 H CS \cell
@@ -2248,7 +2248,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 15JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 15JUL2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 68 H NCS \cell
@@ -2272,7 +2272,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 29JUL2014 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 168 H NCS \cell
@@ -2296,7 +2296,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11AUG2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 11AUG2014 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 254 H CS \cell
@@ -2320,7 +2320,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26AUG2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 26AUG2014 / 06:00 (57) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 513 H CS \cell
@@ -2344,7 +2344,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25SEP2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 25SEP2014 / 06:00 (87) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 273 H CS \cell
@@ -2368,7 +2368,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 21OCT2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 21OCT2014 / 06:00 (113) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 137 H NCS \cell
@@ -2392,7 +2392,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 18NOV2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 18NOV2014 / 06:00 (141) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 512 H CS \cell
@@ -2416,7 +2416,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17DEC2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 17DEC2014 / 06:00 (170) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 579 H CS \cell
@@ -2440,7 +2440,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QRS Duration, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 01JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 01JUL2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 406 N NCS \cell

--- a/tests/testthat/_snaps/lsfecg02part3/lsfecg02part3of3.rtf
+++ b/tests/testthat/_snaps/lsfecg02part3/lsfecg02part3of3.rtf
@@ -64,7 +64,7 @@
 \pard\intbl\qc\fs16 01-701-1023 \cell
 \pard\intbl\qc\fs16 64 / M / Black or African American \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 05AUG2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 05AUG2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 164 N CS \cell
@@ -88,7 +88,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2012 / 06:00 (23) \cell
+\pard\intbl\qc\fs16 27AUG2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 50 N NCS \cell
@@ -112,7 +112,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02SEP2012 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 02SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 73 N NCS \cell
@@ -136,7 +136,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Interpretation \cell
-\pard\intbl\qc\fs16 05AUG2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 05AUG2012 / 08:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL NCS \cell
@@ -160,7 +160,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2012 / 06:00 (23) \cell
+\pard\intbl\qc\fs16 27AUG2012 / 08:00 (23) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -184,7 +184,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02SEP2012 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 02SEP2012 / 08:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -208,7 +208,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05AUG2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 05AUG2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 532 H CS \cell
@@ -232,7 +232,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2012 / 06:00 (23) \cell
+\pard\intbl\qc\fs16 27AUG2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 582 H CS \cell
@@ -256,7 +256,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02SEP2012 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 02SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 243 H CS \cell
@@ -280,7 +280,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QRS Duration, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05AUG2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 05AUG2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 344 N NCS \cell
@@ -304,7 +304,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2012 / 06:00 (23) \cell
+\pard\intbl\qc\fs16 27AUG2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 28 N NCS \cell
@@ -328,7 +328,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02SEP2012 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 02SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 18 N NCS \cell
@@ -352,7 +352,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QT Interval, Corrected (msec) \cell
-\pard\intbl\qc\fs16 05AUG2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 05AUG2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 399 H NCS \cell
@@ -376,7 +376,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2012 / 06:00 (23) \cell
+\pard\intbl\qc\fs16 27AUG2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 471 N NCS \cell
@@ -400,7 +400,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02SEP2012 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 02SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 290 H NCS \cell
@@ -424,7 +424,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcB Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05AUG2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 05AUG2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 208 H NCS \cell
@@ -448,7 +448,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2012 / 06:00 (23) \cell
+\pard\intbl\qc\fs16 27AUG2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 454 H NCS \cell
@@ -472,7 +472,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02SEP2012 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 02SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 353 H NCS \cell
@@ -496,7 +496,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcF Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05AUG2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 05AUG2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 290 H NCS \cell
@@ -520,7 +520,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2012 / 06:00 (23) \cell
+\pard\intbl\qc\fs16 27AUG2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 227 H NCS \cell
@@ -544,7 +544,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02SEP2012 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 02SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 305 H NCS \cell
@@ -568,7 +568,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 RR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05AUG2012 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 05AUG2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 490 L NCS \cell
@@ -592,7 +592,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2012 / 06:00 (23) \cell
+\pard\intbl\qc\fs16 27AUG2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 491 L NCS \cell
@@ -616,7 +616,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02SEP2012 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 02SEP2012 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 548 L NCS \cell
@@ -640,7 +640,7 @@
 \pard\intbl\qc\fs16 01-701-1047 \cell
 \pard\intbl\qc\fs16 85 / F / Native Hawaiian or other Pacific Islander \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 12FEB2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 12FEB2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 363 N CS \cell
@@ -664,7 +664,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25FEB2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 25FEB2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 385 N CS \cell
@@ -688,7 +688,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10MAR2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 10MAR2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 402 N CS \cell
@@ -712,7 +712,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Interpretation \cell
-\pard\intbl\qc\fs16 12FEB2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 12FEB2013 / 07:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL NCS \cell
@@ -736,7 +736,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25FEB2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 25FEB2013 / 07:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL NCS \cell
@@ -760,7 +760,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10MAR2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 10MAR2013 / 07:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -784,7 +784,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 12FEB2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 12FEB2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 320 H CS \cell
@@ -808,7 +808,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25FEB2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 25FEB2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 129 H NCS \cell
@@ -832,7 +832,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10MAR2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 10MAR2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 114 H NCS \cell
@@ -856,7 +856,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QRS Duration, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 12FEB2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 12FEB2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 296 N NCS \cell
@@ -880,7 +880,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25FEB2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 25FEB2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 233 N NCS \cell
@@ -904,7 +904,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10MAR2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 10MAR2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 41 N NCS \cell
@@ -928,7 +928,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QT Interval, Corrected (msec) \cell
-\pard\intbl\qc\fs16 12FEB2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 12FEB2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 351 N NCS \cell
@@ -952,7 +952,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25FEB2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 25FEB2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 344 N NCS \cell
@@ -976,7 +976,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10MAR2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 10MAR2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 236 H NCS \cell
@@ -1000,7 +1000,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcB Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 12FEB2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 12FEB2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 344 H NCS \cell
@@ -1024,7 +1024,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25FEB2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 25FEB2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 429 H NCS \cell
@@ -1048,7 +1048,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10MAR2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 10MAR2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 369 H NCS \cell
@@ -1072,7 +1072,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcF Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 12FEB2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 12FEB2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 465 H NCS \cell
@@ -1096,7 +1096,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25FEB2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 25FEB2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 363 H NCS \cell
@@ -1120,7 +1120,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10MAR2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 10MAR2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 361 H NCS \cell
@@ -1144,7 +1144,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 RR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 12FEB2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 12FEB2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 358 L NCS \cell
@@ -1168,7 +1168,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25FEB2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 25FEB2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 64 L NCS \cell
@@ -1192,7 +1192,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10MAR2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 10MAR2013 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 564 L NCS \cell
@@ -1216,7 +1216,7 @@
 \pard\intbl\qc\fs16 01-701-1118 \cell
 \pard\intbl\qc\fs16 52 / M / Other \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 12MAR2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 12MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 378 N CS \cell
@@ -1240,7 +1240,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26MAR2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 26MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 341 N CS \cell
@@ -1264,7 +1264,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09APR2014 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 09APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 220 N CS \cell
@@ -1288,7 +1288,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23APR2014 / 06:00 (43) \cell
+\pard\intbl\qc\fs16 23APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 160 N CS \cell
@@ -1312,7 +1312,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08MAY2014 / 06:00 (58) \cell
+\pard\intbl\qc\fs16 08MAY2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 447 N CS \cell
@@ -1336,7 +1336,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05JUN2014 / 06:00 (86) \cell
+\pard\intbl\qc\fs16 05JUN2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 241 N CS \cell
@@ -1360,7 +1360,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02JUL2014 / 06:00 (113) \cell
+\pard\intbl\qc\fs16 02JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 535 N CS \cell
@@ -1384,7 +1384,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 30JUL2014 / 06:00 (141) \cell
+\pard\intbl\qc\fs16 30JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 406 N CS \cell
@@ -1408,7 +1408,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2014 / 06:00 (169) \cell
+\pard\intbl\qc\fs16 27AUG2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 228 N CS \cell
@@ -1432,7 +1432,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Interpretation \cell
-\pard\intbl\qc\fs16 12MAR2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 12MAR2014 / 07:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -1456,7 +1456,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26MAR2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 26MAR2014 / 07:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -1480,7 +1480,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09APR2014 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 09APR2014 / 08:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -1504,7 +1504,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23APR2014 / 06:00 (43) \cell
+\pard\intbl\qc\fs16 23APR2014 / 08:00 (43) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -1528,7 +1528,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08MAY2014 / 06:00 (58) \cell
+\pard\intbl\qc\fs16 08MAY2014 / 08:00 (58) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -1552,7 +1552,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05JUN2014 / 06:00 (86) \cell
+\pard\intbl\qc\fs16 05JUN2014 / 08:00 (86) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -1576,7 +1576,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02JUL2014 / 06:00 (113) \cell
+\pard\intbl\qc\fs16 02JUL2014 / 08:00 (113) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -1600,7 +1600,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 30JUL2014 / 06:00 (141) \cell
+\pard\intbl\qc\fs16 30JUL2014 / 08:00 (141) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -1624,7 +1624,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2014 / 06:00 (169) \cell
+\pard\intbl\qc\fs16 27AUG2014 / 08:00 (169) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -1648,7 +1648,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 12MAR2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 12MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 166 H NCS \cell
@@ -1672,7 +1672,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26MAR2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 26MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 54 H NCS \cell
@@ -1696,7 +1696,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09APR2014 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 09APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 259 H CS \cell
@@ -1720,7 +1720,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23APR2014 / 06:00 (43) \cell
+\pard\intbl\qc\fs16 23APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 383 H CS \cell
@@ -1744,7 +1744,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08MAY2014 / 06:00 (58) \cell
+\pard\intbl\qc\fs16 08MAY2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 411 H CS \cell
@@ -1768,7 +1768,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05JUN2014 / 06:00 (86) \cell
+\pard\intbl\qc\fs16 05JUN2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 321 H CS \cell
@@ -1792,7 +1792,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02JUL2014 / 06:00 (113) \cell
+\pard\intbl\qc\fs16 02JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 308 H CS \cell
@@ -1816,7 +1816,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 30JUL2014 / 06:00 (141) \cell
+\pard\intbl\qc\fs16 30JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 172 H NCS \cell
@@ -1840,7 +1840,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2014 / 06:00 (169) \cell
+\pard\intbl\qc\fs16 27AUG2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 517 H CS \cell
@@ -1864,7 +1864,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QRS Duration, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 12MAR2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 12MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 129 N NCS \cell
@@ -1888,7 +1888,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26MAR2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 26MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 66 N NCS \cell
@@ -1912,7 +1912,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09APR2014 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 09APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 520 N NCS \cell
@@ -1936,7 +1936,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23APR2014 / 06:00 (43) \cell
+\pard\intbl\qc\fs16 23APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 120 N NCS \cell
@@ -1960,7 +1960,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08MAY2014 / 06:00 (58) \cell
+\pard\intbl\qc\fs16 08MAY2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 349 N NCS \cell
@@ -1984,7 +1984,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05JUN2014 / 06:00 (86) \cell
+\pard\intbl\qc\fs16 05JUN2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 379 N NCS \cell
@@ -2008,7 +2008,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02JUL2014 / 06:00 (113) \cell
+\pard\intbl\qc\fs16 02JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 333 N NCS \cell
@@ -2032,7 +2032,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 30JUL2014 / 06:00 (141) \cell
+\pard\intbl\qc\fs16 30JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 241 N NCS \cell
@@ -2056,7 +2056,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2014 / 06:00 (169) \cell
+\pard\intbl\qc\fs16 27AUG2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 439 N NCS \cell
@@ -2080,7 +2080,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QT Interval, Corrected (msec) \cell
-\pard\intbl\qc\fs16 12MAR2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 12MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 272 H NCS \cell
@@ -2104,7 +2104,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26MAR2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 26MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 291 N NCS \cell
@@ -2128,7 +2128,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09APR2014 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 09APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 330 N NCS \cell
@@ -2152,7 +2152,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23APR2014 / 06:00 (43) \cell
+\pard\intbl\qc\fs16 23APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 229 N NCS \cell
@@ -2176,7 +2176,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08MAY2014 / 06:00 (58) \cell
+\pard\intbl\qc\fs16 08MAY2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 414 H NCS \cell
@@ -2200,7 +2200,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05JUN2014 / 06:00 (86) \cell
+\pard\intbl\qc\fs16 05JUN2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 470 N NCS \cell
@@ -2224,7 +2224,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02JUL2014 / 06:00 (113) \cell
+\pard\intbl\qc\fs16 02JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 257 H NCS \cell
@@ -2248,7 +2248,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 30JUL2014 / 06:00 (141) \cell
+\pard\intbl\qc\fs16 30JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 463 H NCS \cell
@@ -2272,7 +2272,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2014 / 06:00 (169) \cell
+\pard\intbl\qc\fs16 27AUG2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 299 H NCS \cell
@@ -2296,7 +2296,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcB Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 12MAR2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 12MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 494 H NCS \cell
@@ -2320,7 +2320,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26MAR2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 26MAR2014 / 07:00 (--) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 506 H CS \cell
@@ -2344,7 +2344,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09APR2014 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 09APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 504 H CS \cell
@@ -2368,7 +2368,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23APR2014 / 06:00 (43) \cell
+\pard\intbl\qc\fs16 23APR2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 360 H NCS \cell
@@ -2392,7 +2392,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08MAY2014 / 06:00 (58) \cell
+\pard\intbl\qc\fs16 08MAY2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 364 H NCS \cell
@@ -2416,7 +2416,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05JUN2014 / 06:00 (86) \cell
+\pard\intbl\qc\fs16 05JUN2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 270 H NCS \cell
@@ -2440,7 +2440,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02JUL2014 / 06:00 (113) \cell
+\pard\intbl\qc\fs16 02JUL2014 / 08:00 (--) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 518 H CS \cell

--- a/tests/testthat/_snaps/lsfecg02part3/lsfecg02part3of3.rtf
+++ b/tests/testthat/_snaps/lsfecg02part3/lsfecg02part3of3.rtf
@@ -64,7 +64,7 @@
 \pard\intbl\qc\fs16 01-701-1023 \cell
 \pard\intbl\qc\fs16 64 / M / Black or African American \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 05AUG2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 05AUG2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 164 N CS \cell
@@ -88,7 +88,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 27AUG2012 / 06:00 (23) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 50 N NCS \cell
@@ -112,7 +112,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 02SEP2012 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 73 N NCS \cell
@@ -136,7 +136,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Interpretation \cell
-\pard\intbl\qc\fs16 05AUG2012 / 08:00 (1) \cell
+\pard\intbl\qc\fs16 05AUG2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL NCS \cell
@@ -160,7 +160,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2012 / 08:00 (23) \cell
+\pard\intbl\qc\fs16 27AUG2012 / 06:00 (23) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -184,7 +184,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02SEP2012 / 08:00 (29) \cell
+\pard\intbl\qc\fs16 02SEP2012 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -208,7 +208,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05AUG2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 05AUG2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 532 H CS \cell
@@ -232,7 +232,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 27AUG2012 / 06:00 (23) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 582 H CS \cell
@@ -256,7 +256,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 02SEP2012 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 243 H CS \cell
@@ -280,7 +280,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QRS Duration, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05AUG2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 05AUG2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 344 N NCS \cell
@@ -304,7 +304,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 27AUG2012 / 06:00 (23) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 28 N NCS \cell
@@ -328,7 +328,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 02SEP2012 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 18 N NCS \cell
@@ -352,7 +352,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QT Interval, Corrected (msec) \cell
-\pard\intbl\qc\fs16 05AUG2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 05AUG2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 399 H NCS \cell
@@ -376,7 +376,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 27AUG2012 / 06:00 (23) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 471 N NCS \cell
@@ -400,7 +400,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 02SEP2012 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 290 H NCS \cell
@@ -424,7 +424,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcB Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05AUG2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 05AUG2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 208 H NCS \cell
@@ -448,7 +448,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 27AUG2012 / 06:00 (23) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 454 H NCS \cell
@@ -472,7 +472,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 02SEP2012 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 353 H NCS \cell
@@ -496,7 +496,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcF Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05AUG2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 05AUG2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 290 H NCS \cell
@@ -520,7 +520,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 27AUG2012 / 06:00 (23) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 227 H NCS \cell
@@ -544,7 +544,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 02SEP2012 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 305 H NCS \cell
@@ -568,7 +568,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 RR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 05AUG2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 05AUG2012 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 490 L NCS \cell
@@ -592,7 +592,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 27AUG2012 / 06:00 (23) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 491 L NCS \cell
@@ -616,7 +616,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02SEP2012 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 02SEP2012 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 548 L NCS \cell
@@ -640,7 +640,7 @@
 \pard\intbl\qc\fs16 01-701-1047 \cell
 \pard\intbl\qc\fs16 85 / F / Native Hawaiian or other Pacific Islander \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 12FEB2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12FEB2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 363 N CS \cell
@@ -664,7 +664,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25FEB2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 25FEB2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 385 N CS \cell
@@ -688,7 +688,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10MAR2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 10MAR2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 402 N CS \cell
@@ -712,7 +712,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Interpretation \cell
-\pard\intbl\qc\fs16 12FEB2013 / 07:00 (1) \cell
+\pard\intbl\qc\fs16 12FEB2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL NCS \cell
@@ -736,7 +736,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25FEB2013 / 07:00 (14) \cell
+\pard\intbl\qc\fs16 25FEB2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL NCS \cell
@@ -760,7 +760,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10MAR2013 / 07:00 (27) \cell
+\pard\intbl\qc\fs16 10MAR2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -784,7 +784,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 12FEB2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12FEB2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 320 H CS \cell
@@ -808,7 +808,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25FEB2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 25FEB2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 129 H NCS \cell
@@ -832,7 +832,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10MAR2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 10MAR2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 114 H NCS \cell
@@ -856,7 +856,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QRS Duration, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 12FEB2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12FEB2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 296 N NCS \cell
@@ -880,7 +880,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25FEB2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 25FEB2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 233 N NCS \cell
@@ -904,7 +904,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10MAR2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 10MAR2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 41 N NCS \cell
@@ -928,7 +928,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QT Interval, Corrected (msec) \cell
-\pard\intbl\qc\fs16 12FEB2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12FEB2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 351 N NCS \cell
@@ -952,7 +952,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25FEB2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 25FEB2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 344 N NCS \cell
@@ -976,7 +976,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10MAR2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 10MAR2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 236 H NCS \cell
@@ -1000,7 +1000,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcB Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 12FEB2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12FEB2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 344 H NCS \cell
@@ -1024,7 +1024,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25FEB2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 25FEB2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 429 H NCS \cell
@@ -1048,7 +1048,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10MAR2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 10MAR2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 369 H NCS \cell
@@ -1072,7 +1072,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcF Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 12FEB2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12FEB2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 465 H NCS \cell
@@ -1096,7 +1096,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25FEB2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 25FEB2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 363 H NCS \cell
@@ -1120,7 +1120,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10MAR2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 10MAR2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 361 H NCS \cell
@@ -1144,7 +1144,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 RR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 12FEB2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12FEB2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 358 L NCS \cell
@@ -1168,7 +1168,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25FEB2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 25FEB2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 64 L NCS \cell
@@ -1192,7 +1192,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10MAR2013 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 10MAR2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 564 L NCS \cell
@@ -1216,7 +1216,7 @@
 \pard\intbl\qc\fs16 01-701-1118 \cell
 \pard\intbl\qc\fs16 52 / M / Other \cell
 \pard\intbl\qc\fs16 ECG Mean Heart Rate (beats/min) \cell
-\pard\intbl\qc\fs16 12MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12MAR2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 378 N CS \cell
@@ -1240,7 +1240,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 26MAR2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 341 N CS \cell
@@ -1264,7 +1264,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 09APR2014 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 220 N CS \cell
@@ -1288,7 +1288,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 23APR2014 / 06:00 (43) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 160 N CS \cell
@@ -1312,7 +1312,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08MAY2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 08MAY2014 / 06:00 (58) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 447 N CS \cell
@@ -1336,7 +1336,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05JUN2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 05JUN2014 / 06:00 (86) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 241 N CS \cell
@@ -1360,7 +1360,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 02JUL2014 / 06:00 (113) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 535 N CS \cell
@@ -1384,7 +1384,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 30JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 30JUL2014 / 06:00 (141) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 406 N CS \cell
@@ -1408,7 +1408,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 27AUG2014 / 06:00 (169) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 228 N CS \cell
@@ -1432,7 +1432,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Interpretation \cell
-\pard\intbl\qc\fs16 12MAR2014 / 07:00 (1) \cell
+\pard\intbl\qc\fs16 12MAR2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -1456,7 +1456,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26MAR2014 / 07:00 (15) \cell
+\pard\intbl\qc\fs16 26MAR2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -1480,7 +1480,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09APR2014 / 08:00 (29) \cell
+\pard\intbl\qc\fs16 09APR2014 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -1504,7 +1504,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23APR2014 / 08:00 (43) \cell
+\pard\intbl\qc\fs16 23APR2014 / 06:00 (43) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -1528,7 +1528,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08MAY2014 / 08:00 (58) \cell
+\pard\intbl\qc\fs16 08MAY2014 / 06:00 (58) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -1552,7 +1552,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05JUN2014 / 08:00 (86) \cell
+\pard\intbl\qc\fs16 05JUN2014 / 06:00 (86) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -1576,7 +1576,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02JUL2014 / 08:00 (113) \cell
+\pard\intbl\qc\fs16 02JUL2014 / 06:00 (113) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -1600,7 +1600,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 30JUL2014 / 08:00 (141) \cell
+\pard\intbl\qc\fs16 30JUL2014 / 06:00 (141) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 NORMAL \cell
@@ -1624,7 +1624,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2014 / 08:00 (169) \cell
+\pard\intbl\qc\fs16 27AUG2014 / 06:00 (169) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 ABNORMAL CS \cell
@@ -1648,7 +1648,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 PR Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 12MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12MAR2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 166 H NCS \cell
@@ -1672,7 +1672,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 26MAR2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 54 H NCS \cell
@@ -1696,7 +1696,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 09APR2014 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 259 H CS \cell
@@ -1720,7 +1720,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 23APR2014 / 06:00 (43) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 383 H CS \cell
@@ -1744,7 +1744,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08MAY2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 08MAY2014 / 06:00 (58) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 411 H CS \cell
@@ -1768,7 +1768,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05JUN2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 05JUN2014 / 06:00 (86) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 321 H CS \cell
@@ -1792,7 +1792,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 02JUL2014 / 06:00 (113) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 308 H CS \cell
@@ -1816,7 +1816,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 30JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 30JUL2014 / 06:00 (141) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 172 H NCS \cell
@@ -1840,7 +1840,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 27AUG2014 / 06:00 (169) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 517 H CS \cell
@@ -1864,7 +1864,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QRS Duration, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 12MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12MAR2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 129 N NCS \cell
@@ -1888,7 +1888,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 26MAR2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 66 N NCS \cell
@@ -1912,7 +1912,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 09APR2014 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 520 N NCS \cell
@@ -1936,7 +1936,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 23APR2014 / 06:00 (43) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 120 N NCS \cell
@@ -1960,7 +1960,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08MAY2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 08MAY2014 / 06:00 (58) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 349 N NCS \cell
@@ -1984,7 +1984,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05JUN2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 05JUN2014 / 06:00 (86) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 379 N NCS \cell
@@ -2008,7 +2008,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 02JUL2014 / 06:00 (113) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 333 N NCS \cell
@@ -2032,7 +2032,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 30JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 30JUL2014 / 06:00 (141) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 241 N NCS \cell
@@ -2056,7 +2056,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 27AUG2014 / 06:00 (169) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 439 N NCS \cell
@@ -2080,7 +2080,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QT Interval, Corrected (msec) \cell
-\pard\intbl\qc\fs16 12MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12MAR2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 272 H NCS \cell
@@ -2104,7 +2104,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 26MAR2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 291 N NCS \cell
@@ -2128,7 +2128,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 09APR2014 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 330 N NCS \cell
@@ -2152,7 +2152,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 23APR2014 / 06:00 (43) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 229 N NCS \cell
@@ -2176,7 +2176,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08MAY2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 08MAY2014 / 06:00 (58) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 414 H NCS \cell
@@ -2200,7 +2200,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05JUN2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 05JUN2014 / 06:00 (86) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 470 N NCS \cell
@@ -2224,7 +2224,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 02JUL2014 / 06:00 (113) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 257 H NCS \cell
@@ -2248,7 +2248,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 30JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 30JUL2014 / 06:00 (141) \cell
 \pard\intbl\qc\fs16 Month 18 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 463 H NCS \cell
@@ -2272,7 +2272,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 27AUG2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 27AUG2014 / 06:00 (169) \cell
 \pard\intbl\qc\fs16 Month 24 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 299 H NCS \cell
@@ -2296,7 +2296,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 QTcB Interval, Aggregate (msec) \cell
-\pard\intbl\qc\fs16 12MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 12MAR2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Baseline \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 494 H NCS \cell
@@ -2320,7 +2320,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26MAR2014 / 07:00 (--) \cell
+\pard\intbl\qc\fs16 26MAR2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Month 1 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 506 H CS \cell
@@ -2344,7 +2344,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 09APR2014 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Month 3 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 504 H CS \cell
@@ -2368,7 +2368,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 23APR2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 23APR2014 / 06:00 (43) \cell
 \pard\intbl\qc\fs16 Month 6 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 360 H NCS \cell
@@ -2392,7 +2392,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 08MAY2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 08MAY2014 / 06:00 (58) \cell
 \pard\intbl\qc\fs16 Month 9 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 364 H NCS \cell
@@ -2416,7 +2416,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 05JUN2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 05JUN2014 / 06:00 (86) \cell
 \pard\intbl\qc\fs16 Month 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 270 H NCS \cell
@@ -2440,7 +2440,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 02JUL2014 / 08:00 (--) \cell
+\pard\intbl\qc\fs16 02JUL2014 / 06:00 (113) \cell
 \pard\intbl\qc\fs16 Month 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 518 H CS \cell

--- a/tests/testthat/_snaps/lsfvit01/lsfvit01.rtf
+++ b/tests/testthat/_snaps/lsfvit01/lsfvit01.rtf
@@ -64,7 +64,7 @@
 \pard\intbl\qc\fs16 01-701-1028 \cell
 \pard\intbl\qc\fs16 71 / M / Asian \cell
 \pard\intbl\qc\fs16 Diastolic Blood Pressure Orthostatic (mmHg) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 08:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 1 N \cell
@@ -88,7 +88,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 08:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -10 N \cell
@@ -112,7 +112,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2014 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2014 / 08:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -10 N \cell
@@ -136,7 +136,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 08:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 16 N \cell
@@ -160,7 +160,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2014 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2014 / 08:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 16 N \cell
@@ -184,7 +184,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 18 N \cell
@@ -208,7 +208,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2014 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2014 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 18 N \cell
@@ -232,7 +232,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 08:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 19 H \cell
@@ -256,7 +256,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2014 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2014 / 08:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 19 H \cell
@@ -280,7 +280,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 08:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 0 N \cell
@@ -304,7 +304,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2014 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2014 / 08:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 0 N \cell
@@ -328,7 +328,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 07:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 21 N \cell
@@ -352,7 +352,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2014 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2014 / 07:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 17 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 21 N \cell
@@ -376,7 +376,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 08 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -14 N \cell
@@ -400,7 +400,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2014 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2014 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 19 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -14 N \cell
@@ -424,7 +424,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2015 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2015 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 22 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -14 N \cell
@@ -448,7 +448,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 09 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 25 N \cell
@@ -472,7 +472,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2015 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2015 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 21 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 25 N \cell
@@ -496,7 +496,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2016 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2016 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 25 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 25 N \cell
@@ -520,7 +520,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2014 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2014 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 End Of Treatment \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -544,7 +544,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2015 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2015 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 23 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -568,7 +568,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2016 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2016 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 29 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -592,7 +592,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Pulse Rate Orthostatic (beats/min) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 08:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 19 N \cell
@@ -616,7 +616,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 08:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 18 N \cell
@@ -640,7 +640,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2014 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2014 / 08:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 18 N \cell
@@ -664,7 +664,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 08:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 22 N \cell
@@ -688,7 +688,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2014 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2014 / 08:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 22 N \cell
@@ -712,7 +712,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -18 L \cell
@@ -736,7 +736,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2014 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2014 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -18 L \cell
@@ -760,7 +760,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 08:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 17 N \cell
@@ -784,7 +784,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2014 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2014 / 08:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 17 N \cell
@@ -808,7 +808,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 08:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -18 N \cell
@@ -832,7 +832,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2014 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2014 / 08:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -18 N \cell
@@ -856,7 +856,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 07:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -880,7 +880,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2014 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2014 / 07:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 17 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -904,7 +904,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 08 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 8 N \cell
@@ -928,7 +928,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2014 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2014 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 19 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 8 N \cell
@@ -952,7 +952,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2015 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2015 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 22 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 8 N \cell
@@ -976,7 +976,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 09 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -1 N \cell
@@ -1000,7 +1000,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2015 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2015 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 21 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -1 N \cell
@@ -1024,7 +1024,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2016 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2016 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 25 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -1 N \cell
@@ -1048,7 +1048,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2014 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2014 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 End Of Treatment \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 0 L \cell
@@ -1072,7 +1072,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2015 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2015 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 23 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 0 L \cell
@@ -1096,7 +1096,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2016 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2016 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 29 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 0 L \cell
@@ -1120,7 +1120,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Systolic Blood Pressure Orthostatic (mmHg) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 08:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -23 H \cell
@@ -1144,7 +1144,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 08:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -19 H \cell
@@ -1168,7 +1168,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2014 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2014 / 08:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -19 H \cell
@@ -1192,7 +1192,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 08:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -18 H \cell
@@ -1216,7 +1216,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2014 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2014 / 08:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -18 H \cell
@@ -1240,7 +1240,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -13 H \cell
@@ -1264,7 +1264,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2014 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2014 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -13 H \cell
@@ -1288,7 +1288,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 08:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 2 H \cell
@@ -1312,7 +1312,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2014 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2014 / 08:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 2 H \cell
@@ -1336,7 +1336,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 08:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 26 H \cell
@@ -1360,7 +1360,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2014 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2014 / 08:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 26 H \cell
@@ -1384,7 +1384,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 07:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -4 N \cell
@@ -1408,7 +1408,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2014 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2014 / 07:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 17 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -4 N \cell
@@ -1432,7 +1432,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 08 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -6 N \cell
@@ -1456,7 +1456,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2014 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2014 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 19 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -6 N \cell
@@ -1480,7 +1480,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2015 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2015 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 22 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -6 N \cell
@@ -1504,7 +1504,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 09 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 7 H \cell
@@ -1528,7 +1528,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2015 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2015 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 21 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 7 H \cell
@@ -1552,7 +1552,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2016 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2016 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 25 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 7 H \cell
@@ -1576,7 +1576,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2014 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2014 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 End Of Treatment \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -10 N \cell
@@ -1600,7 +1600,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2015 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2015 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 23 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -10 N \cell
@@ -1624,7 +1624,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2016 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2016 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 29 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -10 N \cell
@@ -1648,7 +1648,7 @@
 \pard\intbl\qc\fs16 01-701-1034 \cell
 \pard\intbl\qc\fs16 77 / F / White \cell
 \pard\intbl\qc\fs16 Diastolic Blood Pressure Orthostatic (mmHg) \cell
-\pard\intbl\qc\fs16 01JUL2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 01JUL2014 / 08:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -8 N \cell
@@ -1672,7 +1672,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 15JUL2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 15JUL2014 / 08:00 (15) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -1 H \cell
@@ -1696,7 +1696,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 15JUL2015 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 15JUL2015 / 08:00 (15) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -1 H \cell
@@ -1720,7 +1720,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29JUL2014 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 29JUL2014 / 08:00 (29) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -15 N \cell
@@ -1744,7 +1744,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29JUL2015 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 29JUL2015 / 08:00 (29) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -15 N \cell
@@ -1768,7 +1768,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11AUG2014 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 11AUG2014 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -6 N \cell
@@ -1792,7 +1792,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11AUG2015 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 11AUG2015 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -6 N \cell
@@ -1816,7 +1816,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26AUG2014 / 06:00 (57) \cell
+\pard\intbl\qc\fs16 26AUG2014 / 08:00 (57) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 1 N \cell
@@ -1840,7 +1840,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26AUG2015 / 06:00 (57) \cell
+\pard\intbl\qc\fs16 26AUG2015 / 08:00 (57) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 1 N \cell
@@ -1864,7 +1864,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25SEP2014 / 06:00 (87) \cell
+\pard\intbl\qc\fs16 25SEP2014 / 08:00 (87) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -17 N \cell
@@ -1888,7 +1888,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25SEP2015 / 06:00 (87) \cell
+\pard\intbl\qc\fs16 25SEP2015 / 08:00 (87) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -17 N \cell
@@ -1912,7 +1912,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 21OCT2014 / 06:00 (113) \cell
+\pard\intbl\qc\fs16 21OCT2014 / 08:00 (113) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 11 N \cell
@@ -1936,7 +1936,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 21OCT2015 / 06:00 (113) \cell
+\pard\intbl\qc\fs16 21OCT2015 / 08:00 (113) \cell
 \pard\intbl\qc\fs16 Cycle 17 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 11 N \cell
@@ -1960,7 +1960,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 18NOV2014 / 06:00 (141) \cell
+\pard\intbl\qc\fs16 18NOV2014 / 07:00 (141) \cell
 \pard\intbl\qc\fs16 Cycle 08 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -16 N \cell
@@ -1984,7 +1984,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 18NOV2015 / 06:00 (141) \cell
+\pard\intbl\qc\fs16 18NOV2015 / 07:00 (141) \cell
 \pard\intbl\qc\fs16 Cycle 19 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -16 N \cell
@@ -2008,7 +2008,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17NOV2016 / 06:00 (141) \cell
+\pard\intbl\qc\fs16 17NOV2016 / 07:00 (141) \cell
 \pard\intbl\qc\fs16 Cycle 22 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -16 N \cell
@@ -2032,7 +2032,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17DEC2014 / 06:00 (170) \cell
+\pard\intbl\qc\fs16 17DEC2014 / 07:00 (170) \cell
 \pard\intbl\qc\fs16 Cycle 09 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 10 H \cell
@@ -2056,7 +2056,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17DEC2015 / 06:00 (170) \cell
+\pard\intbl\qc\fs16 17DEC2015 / 07:00 (170) \cell
 \pard\intbl\qc\fs16 Cycle 21 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 10 H \cell
@@ -2080,7 +2080,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 16DEC2016 / 06:00 (170) \cell
+\pard\intbl\qc\fs16 16DEC2016 / 07:00 (170) \cell
 \pard\intbl\qc\fs16 Cycle 25 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 10 H \cell
@@ -2104,7 +2104,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 30DEC2014 / 06:00 (183) \cell
+\pard\intbl\qc\fs16 30DEC2014 / 07:00 (183) \cell
 \pard\intbl\qc\fs16 End Of Treatment \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -8 N \cell
@@ -2128,7 +2128,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 30DEC2015 / 06:00 (183) \cell
+\pard\intbl\qc\fs16 30DEC2015 / 07:00 (183) \cell
 \pard\intbl\qc\fs16 Cycle 23 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -8 N \cell
@@ -2152,7 +2152,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29DEC2016 / 06:00 (183) \cell
+\pard\intbl\qc\fs16 29DEC2016 / 07:00 (183) \cell
 \pard\intbl\qc\fs16 Cycle 29 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -8 N \cell
@@ -2176,7 +2176,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Pulse Rate Orthostatic (beats/min) \cell
-\pard\intbl\qc\fs16 01JUL2014 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 01JUL2014 / 08:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 14 N \cell
@@ -2200,7 +2200,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 15JUL2014 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 15JUL2014 / 08:00 (15) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 13 N \cell
@@ -2224,7 +2224,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 15JUL2015 / 06:00 (15) \cell
+\pard\intbl\qc\fs16 15JUL2015 / 08:00 (15) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 13 N \cell
@@ -2248,7 +2248,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29JUL2014 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 29JUL2014 / 08:00 (29) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -10 N \cell
@@ -2272,7 +2272,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29JUL2015 / 06:00 (29) \cell
+\pard\intbl\qc\fs16 29JUL2015 / 08:00 (29) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -10 N \cell
@@ -2296,7 +2296,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11AUG2014 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 11AUG2014 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -2320,7 +2320,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11AUG2015 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 11AUG2015 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -2344,7 +2344,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26AUG2014 / 06:00 (57) \cell
+\pard\intbl\qc\fs16 26AUG2014 / 08:00 (57) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 16 N \cell
@@ -2368,7 +2368,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26AUG2015 / 06:00 (57) \cell
+\pard\intbl\qc\fs16 26AUG2015 / 08:00 (57) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 16 N \cell
@@ -2392,7 +2392,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25SEP2014 / 06:00 (87) \cell
+\pard\intbl\qc\fs16 25SEP2014 / 08:00 (87) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -25 N \cell
@@ -2416,7 +2416,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25SEP2015 / 06:00 (87) \cell
+\pard\intbl\qc\fs16 25SEP2015 / 08:00 (87) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -25 N \cell
@@ -2440,7 +2440,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 21OCT2014 / 06:00 (113) \cell
+\pard\intbl\qc\fs16 21OCT2014 / 08:00 (113) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 21 N \cell

--- a/tests/testthat/_snaps/lsfvit01/lsfvit01.rtf
+++ b/tests/testthat/_snaps/lsfvit01/lsfvit01.rtf
@@ -64,7 +64,7 @@
 \pard\intbl\qc\fs16 01-701-1028 \cell
 \pard\intbl\qc\fs16 71 / M / Asian \cell
 \pard\intbl\qc\fs16 Diastolic Blood Pressure Orthostatic (mmHg) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 08:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 1 N \cell
@@ -88,7 +88,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 08:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -10 N \cell
@@ -112,7 +112,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2014 / 08:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2014 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -10 N \cell
@@ -136,7 +136,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 08:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 16 N \cell
@@ -160,7 +160,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2014 / 08:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2014 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 16 N \cell
@@ -184,7 +184,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 18 N \cell
@@ -208,7 +208,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2014 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2014 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 18 N \cell
@@ -232,7 +232,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 08:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 19 H \cell
@@ -256,7 +256,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2014 / 08:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2014 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 19 H \cell
@@ -280,7 +280,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 08:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 0 N \cell
@@ -304,7 +304,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2014 / 08:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2014 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 0 N \cell
@@ -328,7 +328,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 07:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 21 N \cell
@@ -352,7 +352,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2014 / 07:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2014 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 17 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 21 N \cell
@@ -376,7 +376,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 08 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -14 N \cell
@@ -400,7 +400,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2014 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2014 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 19 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -14 N \cell
@@ -424,7 +424,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2015 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2015 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 22 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -14 N \cell
@@ -448,7 +448,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 09 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 25 N \cell
@@ -472,7 +472,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2015 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2015 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 21 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 25 N \cell
@@ -496,7 +496,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2016 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2016 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 25 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 25 N \cell
@@ -520,7 +520,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2014 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2014 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 End Of Treatment \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -544,7 +544,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2015 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2015 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 23 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -568,7 +568,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2016 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2016 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 29 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -592,7 +592,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Pulse Rate Orthostatic (beats/min) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 08:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 19 N \cell
@@ -616,7 +616,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 08:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 18 N \cell
@@ -640,7 +640,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2014 / 08:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2014 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 18 N \cell
@@ -664,7 +664,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 08:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 22 N \cell
@@ -688,7 +688,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2014 / 08:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2014 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 22 N \cell
@@ -712,7 +712,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -18 L \cell
@@ -736,7 +736,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2014 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2014 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -18 L \cell
@@ -760,7 +760,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 08:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 17 N \cell
@@ -784,7 +784,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2014 / 08:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2014 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 17 N \cell
@@ -808,7 +808,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 08:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -18 N \cell
@@ -832,7 +832,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2014 / 08:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2014 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -18 N \cell
@@ -856,7 +856,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 07:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -880,7 +880,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2014 / 07:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2014 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 17 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -904,7 +904,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 08 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 8 N \cell
@@ -928,7 +928,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2014 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2014 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 19 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 8 N \cell
@@ -952,7 +952,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2015 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2015 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 22 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 8 N \cell
@@ -976,7 +976,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 09 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -1 N \cell
@@ -1000,7 +1000,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2015 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2015 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 21 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -1 N \cell
@@ -1024,7 +1024,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2016 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2016 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 25 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -1 N \cell
@@ -1048,7 +1048,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2014 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2014 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 End Of Treatment \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 0 L \cell
@@ -1072,7 +1072,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2015 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2015 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 23 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 0 L \cell
@@ -1096,7 +1096,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2016 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2016 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 29 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 0 L \cell
@@ -1120,7 +1120,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Systolic Blood Pressure Orthostatic (mmHg) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 08:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -23 H \cell
@@ -1144,7 +1144,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 08:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -19 H \cell
@@ -1168,7 +1168,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2014 / 08:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2014 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -19 H \cell
@@ -1192,7 +1192,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 08:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -18 H \cell
@@ -1216,7 +1216,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2014 / 08:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2014 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -18 H \cell
@@ -1240,7 +1240,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -13 H \cell
@@ -1264,7 +1264,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2014 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2014 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -13 H \cell
@@ -1288,7 +1288,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 08:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 2 H \cell
@@ -1312,7 +1312,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2014 / 08:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2014 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 2 H \cell
@@ -1336,7 +1336,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 08:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 26 H \cell
@@ -1360,7 +1360,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2014 / 08:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2014 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 26 H \cell
@@ -1384,7 +1384,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 07:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -4 N \cell
@@ -1408,7 +1408,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2014 / 07:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2014 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 17 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -4 N \cell
@@ -1432,7 +1432,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 08 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -6 N \cell
@@ -1456,7 +1456,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2014 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2014 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 19 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -6 N \cell
@@ -1480,7 +1480,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2015 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2015 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 22 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -6 N \cell
@@ -1504,7 +1504,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 09 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 7 H \cell
@@ -1528,7 +1528,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2015 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2015 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 21 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 7 H \cell
@@ -1552,7 +1552,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2016 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2016 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 25 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 7 H \cell
@@ -1576,7 +1576,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2014 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2014 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 End Of Treatment \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -10 N \cell
@@ -1600,7 +1600,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2015 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2015 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 23 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -10 N \cell
@@ -1624,7 +1624,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2016 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2016 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 29 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -10 N \cell
@@ -1648,7 +1648,7 @@
 \pard\intbl\qc\fs16 01-701-1034 \cell
 \pard\intbl\qc\fs16 77 / F / White \cell
 \pard\intbl\qc\fs16 Diastolic Blood Pressure Orthostatic (mmHg) \cell
-\pard\intbl\qc\fs16 01JUL2014 / 08:00 (1) \cell
+\pard\intbl\qc\fs16 01JUL2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -8 N \cell
@@ -1672,7 +1672,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 15JUL2014 / 08:00 (15) \cell
+\pard\intbl\qc\fs16 15JUL2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -1 H \cell
@@ -1696,7 +1696,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 15JUL2015 / 08:00 (15) \cell
+\pard\intbl\qc\fs16 15JUL2015 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -1 H \cell
@@ -1720,7 +1720,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29JUL2014 / 08:00 (29) \cell
+\pard\intbl\qc\fs16 29JUL2014 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -15 N \cell
@@ -1744,7 +1744,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29JUL2015 / 08:00 (29) \cell
+\pard\intbl\qc\fs16 29JUL2015 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -15 N \cell
@@ -1768,7 +1768,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11AUG2014 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 11AUG2014 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -6 N \cell
@@ -1792,7 +1792,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11AUG2015 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 11AUG2015 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -6 N \cell
@@ -1816,7 +1816,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26AUG2014 / 08:00 (57) \cell
+\pard\intbl\qc\fs16 26AUG2014 / 06:00 (57) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 1 N \cell
@@ -1840,7 +1840,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26AUG2015 / 08:00 (57) \cell
+\pard\intbl\qc\fs16 26AUG2015 / 06:00 (57) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 1 N \cell
@@ -1864,7 +1864,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25SEP2014 / 08:00 (87) \cell
+\pard\intbl\qc\fs16 25SEP2014 / 06:00 (87) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -17 N \cell
@@ -1888,7 +1888,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25SEP2015 / 08:00 (87) \cell
+\pard\intbl\qc\fs16 25SEP2015 / 06:00 (87) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -17 N \cell
@@ -1912,7 +1912,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 21OCT2014 / 08:00 (113) \cell
+\pard\intbl\qc\fs16 21OCT2014 / 06:00 (113) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 11 N \cell
@@ -1936,7 +1936,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 21OCT2015 / 08:00 (113) \cell
+\pard\intbl\qc\fs16 21OCT2015 / 06:00 (113) \cell
 \pard\intbl\qc\fs16 Cycle 17 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 11 N \cell
@@ -1960,7 +1960,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 18NOV2014 / 07:00 (141) \cell
+\pard\intbl\qc\fs16 18NOV2014 / 06:00 (141) \cell
 \pard\intbl\qc\fs16 Cycle 08 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -16 N \cell
@@ -1984,7 +1984,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 18NOV2015 / 07:00 (141) \cell
+\pard\intbl\qc\fs16 18NOV2015 / 06:00 (141) \cell
 \pard\intbl\qc\fs16 Cycle 19 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -16 N \cell
@@ -2008,7 +2008,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17NOV2016 / 07:00 (141) \cell
+\pard\intbl\qc\fs16 17NOV2016 / 06:00 (141) \cell
 \pard\intbl\qc\fs16 Cycle 22 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -16 N \cell
@@ -2032,7 +2032,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17DEC2014 / 07:00 (170) \cell
+\pard\intbl\qc\fs16 17DEC2014 / 06:00 (170) \cell
 \pard\intbl\qc\fs16 Cycle 09 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 10 H \cell
@@ -2056,7 +2056,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 17DEC2015 / 07:00 (170) \cell
+\pard\intbl\qc\fs16 17DEC2015 / 06:00 (170) \cell
 \pard\intbl\qc\fs16 Cycle 21 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 10 H \cell
@@ -2080,7 +2080,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 16DEC2016 / 07:00 (170) \cell
+\pard\intbl\qc\fs16 16DEC2016 / 06:00 (170) \cell
 \pard\intbl\qc\fs16 Cycle 25 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 10 H \cell
@@ -2104,7 +2104,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 30DEC2014 / 07:00 (183) \cell
+\pard\intbl\qc\fs16 30DEC2014 / 06:00 (183) \cell
 \pard\intbl\qc\fs16 End Of Treatment \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -8 N \cell
@@ -2128,7 +2128,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 30DEC2015 / 07:00 (183) \cell
+\pard\intbl\qc\fs16 30DEC2015 / 06:00 (183) \cell
 \pard\intbl\qc\fs16 Cycle 23 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -8 N \cell
@@ -2152,7 +2152,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29DEC2016 / 07:00 (183) \cell
+\pard\intbl\qc\fs16 29DEC2016 / 06:00 (183) \cell
 \pard\intbl\qc\fs16 Cycle 29 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -8 N \cell
@@ -2176,7 +2176,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Pulse Rate Orthostatic (beats/min) \cell
-\pard\intbl\qc\fs16 01JUL2014 / 08:00 (1) \cell
+\pard\intbl\qc\fs16 01JUL2014 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 14 N \cell
@@ -2200,7 +2200,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 15JUL2014 / 08:00 (15) \cell
+\pard\intbl\qc\fs16 15JUL2014 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 13 N \cell
@@ -2224,7 +2224,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 15JUL2015 / 08:00 (15) \cell
+\pard\intbl\qc\fs16 15JUL2015 / 06:00 (15) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 13 N \cell
@@ -2248,7 +2248,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29JUL2014 / 08:00 (29) \cell
+\pard\intbl\qc\fs16 29JUL2014 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -10 N \cell
@@ -2272,7 +2272,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29JUL2015 / 08:00 (29) \cell
+\pard\intbl\qc\fs16 29JUL2015 / 06:00 (29) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -10 N \cell
@@ -2296,7 +2296,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11AUG2014 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 11AUG2014 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -2320,7 +2320,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 11AUG2015 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 11AUG2015 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -2344,7 +2344,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26AUG2014 / 08:00 (57) \cell
+\pard\intbl\qc\fs16 26AUG2014 / 06:00 (57) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 16 N \cell
@@ -2368,7 +2368,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 26AUG2015 / 08:00 (57) \cell
+\pard\intbl\qc\fs16 26AUG2015 / 06:00 (57) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 16 N \cell
@@ -2392,7 +2392,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25SEP2014 / 08:00 (87) \cell
+\pard\intbl\qc\fs16 25SEP2014 / 06:00 (87) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -25 N \cell
@@ -2416,7 +2416,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 25SEP2015 / 08:00 (87) \cell
+\pard\intbl\qc\fs16 25SEP2015 / 06:00 (87) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -25 N \cell
@@ -2440,7 +2440,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 21OCT2014 / 08:00 (113) \cell
+\pard\intbl\qc\fs16 21OCT2014 / 06:00 (113) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 21 N \cell

--- a/tests/testthat/_snaps/lsfvit02/lsfvit02.rtf
+++ b/tests/testthat/_snaps/lsfvit02/lsfvit02.rtf
@@ -64,7 +64,7 @@
 \pard\intbl\qc\fs16 01-701-1028 \cell
 \pard\intbl\qc\fs16 71 / M / Asian \cell
 \pard\intbl\qc\fs16 DBP (STD-SUP) <-10 \cell
-\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 08:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -88,7 +88,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 08:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -112,7 +112,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2014 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2014 / 08:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -136,7 +136,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 08:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -160,7 +160,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2014 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2014 / 08:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -184,7 +184,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -208,7 +208,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2014 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2014 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -232,7 +232,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 08:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -256,7 +256,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2014 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2014 / 08:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -280,7 +280,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 08:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -304,7 +304,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2014 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2014 / 08:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -328,7 +328,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 07:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -352,7 +352,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2014 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2014 / 07:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 17 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -376,7 +376,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 08 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 Y N \cell
@@ -400,7 +400,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2014 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2014 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 19 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 Y N \cell
@@ -424,7 +424,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2015 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2015 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 22 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 Y N \cell
@@ -448,7 +448,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 09 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -472,7 +472,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2015 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2015 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 21 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -496,7 +496,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2016 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2016 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 25 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -520,7 +520,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2014 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2014 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 End Of Treatment \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -544,7 +544,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2015 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2015 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 23 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -568,7 +568,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2016 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2016 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 29 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -592,7 +592,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Diastolic Blood Pressure (mmHg) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 08:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 78.6667 N \cell
@@ -616,7 +616,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 08:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 79.3333 N \cell
@@ -640,7 +640,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2014 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2014 / 08:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 79.3333 N \cell
@@ -664,7 +664,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 08:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 69.6667 N \cell
@@ -688,7 +688,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2014 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2014 / 08:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 69.6667 N \cell
@@ -712,7 +712,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 74.0000 N \cell
@@ -736,7 +736,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2014 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2014 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 74.0000 N \cell
@@ -760,7 +760,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 08:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 80.3333 H \cell
@@ -784,7 +784,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2014 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2014 / 08:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 80.3333 H \cell
@@ -808,7 +808,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 08:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 79.0000 N \cell
@@ -832,7 +832,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2014 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2014 / 08:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 79.0000 N \cell
@@ -856,7 +856,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 07:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 76.3333 N \cell
@@ -880,7 +880,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2014 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2014 / 07:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 17 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 76.3333 N \cell
@@ -904,7 +904,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 08 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 77.3333 N \cell
@@ -928,7 +928,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2014 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2014 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 19 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 77.3333 N \cell
@@ -952,7 +952,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2015 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2015 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 22 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 77.3333 N \cell
@@ -976,7 +976,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 09 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 74.0000 N \cell
@@ -1000,7 +1000,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2015 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2015 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 21 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 74.0000 N \cell
@@ -1024,7 +1024,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2016 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2016 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 25 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 74.0000 N \cell
@@ -1048,7 +1048,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2014 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2014 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 End Of Treatment \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 75.3333 N \cell
@@ -1072,7 +1072,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2015 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2015 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 23 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 75.3333 N \cell
@@ -1096,7 +1096,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2016 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2016 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 29 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 75.3333 N \cell
@@ -1120,7 +1120,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Diastolic Blood Pressure Orthostatic (mmHg) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 08:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 1 N \cell
@@ -1144,7 +1144,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 08:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -10 N \cell
@@ -1168,7 +1168,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2014 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2014 / 08:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -10 N \cell
@@ -1192,7 +1192,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 08:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 16 N \cell
@@ -1216,7 +1216,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2014 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2014 / 08:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 16 N \cell
@@ -1240,7 +1240,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 18 N \cell
@@ -1264,7 +1264,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2014 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2014 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 18 N \cell
@@ -1288,7 +1288,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 08:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 19 H \cell
@@ -1312,7 +1312,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2014 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2014 / 08:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 19 H \cell
@@ -1336,7 +1336,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 08:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 0 N \cell
@@ -1360,7 +1360,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2014 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2014 / 08:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 0 N \cell
@@ -1384,7 +1384,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 07:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 21 N \cell
@@ -1408,7 +1408,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2014 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2014 / 07:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 17 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 21 N \cell
@@ -1432,7 +1432,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 08 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -14 N \cell
@@ -1456,7 +1456,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2014 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2014 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 19 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -14 N \cell
@@ -1480,7 +1480,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2015 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2015 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 22 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -14 N \cell
@@ -1504,7 +1504,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 09 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 25 N \cell
@@ -1528,7 +1528,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2015 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2015 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 21 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 25 N \cell
@@ -1552,7 +1552,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2016 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2016 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 25 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 25 N \cell
@@ -1576,7 +1576,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2014 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2014 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 End Of Treatment \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -1600,7 +1600,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2015 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2015 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 23 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -1624,7 +1624,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2016 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2016 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 29 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -1648,7 +1648,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Orthostatic Hypotension \cell
-\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 08:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 Y H \cell
@@ -1672,7 +1672,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 08:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1696,7 +1696,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2014 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2014 / 08:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1720,7 +1720,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 08:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1744,7 +1744,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2014 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2014 / 08:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1768,7 +1768,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1792,7 +1792,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2014 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2014 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1816,7 +1816,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 08:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1840,7 +1840,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2014 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2014 / 08:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1864,7 +1864,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 08:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1888,7 +1888,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2014 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2014 / 08:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1912,7 +1912,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 07:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -1936,7 +1936,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2014 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2014 / 07:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 17 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -1960,7 +1960,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 08 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 Y N \cell
@@ -1984,7 +1984,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2014 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2014 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 19 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 Y N \cell
@@ -2008,7 +2008,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2015 / 06:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2015 / 07:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 22 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 Y N \cell
@@ -2032,7 +2032,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 09 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -2056,7 +2056,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2015 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2015 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 21 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -2080,7 +2080,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2016 / 06:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2016 / 07:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 25 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -2104,7 +2104,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2014 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2014 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 End Of Treatment \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -2128,7 +2128,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2015 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2015 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 23 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -2152,7 +2152,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2016 / 06:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2016 / 07:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 29 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -2176,7 +2176,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Pulse Rate (beats/min) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 08:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 63.3333 N \cell
@@ -2200,7 +2200,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 08:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 71.3333 N \cell
@@ -2224,7 +2224,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2014 / 06:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2014 / 08:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 71.3333 N \cell
@@ -2248,7 +2248,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 08:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 75.0000 N \cell
@@ -2272,7 +2272,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2014 / 06:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2014 / 08:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 75.0000 N \cell
@@ -2296,7 +2296,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 59.3333 L \cell
@@ -2320,7 +2320,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2014 / 06:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2014 / 08:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 59.3333 L \cell
@@ -2344,7 +2344,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 08:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 74.6667 N \cell
@@ -2368,7 +2368,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2014 / 06:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2014 / 08:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 74.6667 N \cell
@@ -2392,7 +2392,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 08:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 65.0000 N \cell
@@ -2416,7 +2416,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2014 / 06:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2014 / 08:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 65.0000 N \cell
@@ -2440,7 +2440,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 07:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 66.3333 N \cell

--- a/tests/testthat/_snaps/lsfvit02/lsfvit02.rtf
+++ b/tests/testthat/_snaps/lsfvit02/lsfvit02.rtf
@@ -64,7 +64,7 @@
 \pard\intbl\qc\fs16 01-701-1028 \cell
 \pard\intbl\qc\fs16 71 / M / Asian \cell
 \pard\intbl\qc\fs16 DBP (STD-SUP) <-10 \cell
-\pard\intbl\qc\fs16 19JUL2013 / 08:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -88,7 +88,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 08:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -112,7 +112,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2014 / 08:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2014 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -136,7 +136,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 08:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -160,7 +160,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2014 / 08:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2014 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -184,7 +184,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -208,7 +208,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2014 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2014 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -232,7 +232,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 08:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -256,7 +256,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2014 / 08:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2014 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -280,7 +280,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 08:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -304,7 +304,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2014 / 08:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2014 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -328,7 +328,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 07:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -352,7 +352,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2014 / 07:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2014 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 17 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -376,7 +376,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 08 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 Y N \cell
@@ -400,7 +400,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2014 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2014 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 19 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 Y N \cell
@@ -424,7 +424,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2015 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2015 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 22 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 Y N \cell
@@ -448,7 +448,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 09 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -472,7 +472,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2015 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2015 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 21 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -496,7 +496,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2016 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2016 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 25 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -520,7 +520,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2014 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2014 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 End Of Treatment \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -544,7 +544,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2015 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2015 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 23 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -568,7 +568,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2016 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2016 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 29 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -592,7 +592,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Diastolic Blood Pressure (mmHg) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 08:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 78.6667 N \cell
@@ -616,7 +616,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 08:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 79.3333 N \cell
@@ -640,7 +640,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2014 / 08:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2014 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 79.3333 N \cell
@@ -664,7 +664,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 08:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 69.6667 N \cell
@@ -688,7 +688,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2014 / 08:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2014 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 69.6667 N \cell
@@ -712,7 +712,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 74.0000 N \cell
@@ -736,7 +736,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2014 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2014 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 74.0000 N \cell
@@ -760,7 +760,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 08:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 80.3333 H \cell
@@ -784,7 +784,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2014 / 08:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2014 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 80.3333 H \cell
@@ -808,7 +808,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 08:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 79.0000 N \cell
@@ -832,7 +832,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2014 / 08:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2014 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 79.0000 N \cell
@@ -856,7 +856,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 07:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 76.3333 N \cell
@@ -880,7 +880,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2014 / 07:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2014 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 17 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 76.3333 N \cell
@@ -904,7 +904,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 08 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 77.3333 N \cell
@@ -928,7 +928,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2014 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2014 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 19 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 77.3333 N \cell
@@ -952,7 +952,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2015 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2015 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 22 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 77.3333 N \cell
@@ -976,7 +976,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 09 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 74.0000 N \cell
@@ -1000,7 +1000,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2015 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2015 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 21 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 74.0000 N \cell
@@ -1024,7 +1024,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2016 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2016 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 25 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 74.0000 N \cell
@@ -1048,7 +1048,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2014 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2014 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 End Of Treatment \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 75.3333 N \cell
@@ -1072,7 +1072,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2015 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2015 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 23 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 75.3333 N \cell
@@ -1096,7 +1096,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2016 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2016 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 29 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 75.3333 N \cell
@@ -1120,7 +1120,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Diastolic Blood Pressure Orthostatic (mmHg) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 08:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 1 N \cell
@@ -1144,7 +1144,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 08:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -10 N \cell
@@ -1168,7 +1168,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2014 / 08:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2014 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -10 N \cell
@@ -1192,7 +1192,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 08:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 16 N \cell
@@ -1216,7 +1216,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2014 / 08:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2014 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 16 N \cell
@@ -1240,7 +1240,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 18 N \cell
@@ -1264,7 +1264,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2014 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2014 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 18 N \cell
@@ -1288,7 +1288,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 08:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 19 H \cell
@@ -1312,7 +1312,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2014 / 08:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2014 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 19 H \cell
@@ -1336,7 +1336,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 08:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 0 N \cell
@@ -1360,7 +1360,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2014 / 08:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2014 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 0 N \cell
@@ -1384,7 +1384,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 07:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 21 N \cell
@@ -1408,7 +1408,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2014 / 07:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2014 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 17 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 21 N \cell
@@ -1432,7 +1432,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 08 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -14 N \cell
@@ -1456,7 +1456,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2014 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2014 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 19 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -14 N \cell
@@ -1480,7 +1480,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2015 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2015 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 22 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 -14 N \cell
@@ -1504,7 +1504,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 09 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 25 N \cell
@@ -1528,7 +1528,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2015 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2015 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 21 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 25 N \cell
@@ -1552,7 +1552,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2016 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2016 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 25 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 25 N \cell
@@ -1576,7 +1576,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2014 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2014 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 End Of Treatment \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -1600,7 +1600,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2015 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2015 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 23 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -1624,7 +1624,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2016 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2016 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 29 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 9 N \cell
@@ -1648,7 +1648,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Orthostatic Hypotension \cell
-\pard\intbl\qc\fs16 19JUL2013 / 08:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 Y H \cell
@@ -1672,7 +1672,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 08:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1696,7 +1696,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2014 / 08:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2014 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1720,7 +1720,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 08:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1744,7 +1744,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2014 / 08:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2014 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1768,7 +1768,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1792,7 +1792,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2014 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2014 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1816,7 +1816,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 08:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1840,7 +1840,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2014 / 08:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2014 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1864,7 +1864,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 08:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1888,7 +1888,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2014 / 08:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2014 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -1912,7 +1912,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 07:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -1936,7 +1936,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2014 / 07:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2014 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 17 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -1960,7 +1960,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2013 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2013 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 08 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 Y N \cell
@@ -1984,7 +1984,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2014 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2014 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 19 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 Y N \cell
@@ -2008,7 +2008,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 04DEC2015 / 07:00 (139) \cell
+\pard\intbl\qc\fs16 04DEC2015 / 06:00 (139) \cell
 \pard\intbl\qc\fs16 Cycle 22 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 Y N \cell
@@ -2032,7 +2032,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2014 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2014 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 09 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -2056,7 +2056,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2015 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2015 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 21 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -2080,7 +2080,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06JAN2016 / 07:00 (172) \cell
+\pard\intbl\qc\fs16 06JAN2016 / 06:00 (172) \cell
 \pard\intbl\qc\fs16 Cycle 25 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N H \cell
@@ -2104,7 +2104,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2014 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2014 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 End Of Treatment \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -2128,7 +2128,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2015 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2015 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 23 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -2152,7 +2152,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14JAN2016 / 07:00 (180) \cell
+\pard\intbl\qc\fs16 14JAN2016 / 06:00 (180) \cell
 \pard\intbl\qc\fs16 Cycle 29 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 N N \cell
@@ -2176,7 +2176,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16 Pulse Rate (beats/min) \cell
-\pard\intbl\qc\fs16 19JUL2013 / 08:00 (1) \cell
+\pard\intbl\qc\fs16 19JUL2013 / 06:00 (1) \cell
 \pard\intbl\qc\fs16 Screening \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 63.3333 N \cell
@@ -2200,7 +2200,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2013 / 08:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2013 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 02 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 71.3333 N \cell
@@ -2224,7 +2224,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 01AUG2014 / 08:00 (14) \cell
+\pard\intbl\qc\fs16 01AUG2014 / 06:00 (14) \cell
 \pard\intbl\qc\fs16 Cycle 10 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 71.3333 N \cell
@@ -2248,7 +2248,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2013 / 08:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2013 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 03 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 75.0000 N \cell
@@ -2272,7 +2272,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 14AUG2014 / 08:00 (27) \cell
+\pard\intbl\qc\fs16 14AUG2014 / 06:00 (27) \cell
 \pard\intbl\qc\fs16 Cycle 11 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 75.0000 N \cell
@@ -2296,7 +2296,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2013 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2013 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 04 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 59.3333 L \cell
@@ -2320,7 +2320,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 29AUG2014 / 08:00 (42) \cell
+\pard\intbl\qc\fs16 29AUG2014 / 06:00 (42) \cell
 \pard\intbl\qc\fs16 Cycle 12 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 59.3333 L \cell
@@ -2344,7 +2344,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2013 / 08:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2013 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 05 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 74.6667 N \cell
@@ -2368,7 +2368,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 10SEP2014 / 08:00 (54) \cell
+\pard\intbl\qc\fs16 10SEP2014 / 06:00 (54) \cell
 \pard\intbl\qc\fs16 Cycle 13 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 74.6667 N \cell
@@ -2392,7 +2392,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2013 / 08:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2013 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 06 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 65.0000 N \cell
@@ -2416,7 +2416,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 09OCT2014 / 08:00 (83) \cell
+\pard\intbl\qc\fs16 09OCT2014 / 06:00 (83) \cell
 \pard\intbl\qc\fs16 Cycle 15 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 65.0000 N \cell
@@ -2440,7 +2440,7 @@
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
 \pard\intbl\qc\fs16  \cell
-\pard\intbl\qc\fs16 06NOV2013 / 07:00 (111) \cell
+\pard\intbl\qc\fs16 06NOV2013 / 06:00 (111) \cell
 \pard\intbl\qc\fs16 Cycle 07 \cell
 \pard\intbl\qc\fs16 BEFORE TREATMENT \cell
 \pard\intbl\qc\fs16 66.3333 N \cell

--- a/tests/testthat/_snaps/lsidem02/lsidem02.rtf
+++ b/tests/testthat/_snaps/lsidem02/lsidem02.rtf
@@ -58,7 +58,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1023 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 05AUG2012 / 11:59 \cell
+\pard\intbl\qc\fs16 05AUG2012 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -80,7 +80,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1028 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 19JUL2013 / 11:59 \cell
+\pard\intbl\qc\fs16 19JUL2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -102,7 +102,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1033 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 18MAR2014 / 11:59 \cell
+\pard\intbl\qc\fs16 18MAR2014 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -124,7 +124,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1034 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 01JUL2014 / 11:59 \cell
+\pard\intbl\qc\fs16 01JUL2014 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -146,7 +146,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1047 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 12FEB2013 / 11:59 \cell
+\pard\intbl\qc\fs16 12FEB2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -168,7 +168,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1111 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 07SEP2012 / 11:59 \cell
+\pard\intbl\qc\fs16 07SEP2012 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -190,7 +190,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1115 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 30NOV2012 / 11:59 \cell
+\pard\intbl\qc\fs16 30NOV2012 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -212,7 +212,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1118 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 12MAR2014 / 11:59 \cell
+\pard\intbl\qc\fs16 12MAR2014 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -234,7 +234,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1130 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 15FEB2014 / 11:59 \cell
+\pard\intbl\qc\fs16 15FEB2014 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -256,7 +256,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1146 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 20MAY2013 / 11:59 \cell
+\pard\intbl\qc\fs16 20MAY2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -278,7 +278,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1148 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 23AUG2013 / 11:59 \cell
+\pard\intbl\qc\fs16 23AUG2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -300,7 +300,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1181 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 05DEC2013 / 11:59 \cell
+\pard\intbl\qc\fs16 05DEC2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -322,7 +322,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1188 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 15FEB2013 / 11:59 \cell
+\pard\intbl\qc\fs16 15FEB2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -344,7 +344,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1192 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 22JUL2012 / 11:59 \cell
+\pard\intbl\qc\fs16 22JUL2012 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -366,7 +366,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1203 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 02FEB2013 / 11:59 \cell
+\pard\intbl\qc\fs16 02FEB2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -388,7 +388,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1211 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 15NOV2012 / 11:59 \cell
+\pard\intbl\qc\fs16 15NOV2012 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -410,7 +410,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1239 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 11JAN2014 / 11:59 \cell
+\pard\intbl\qc\fs16 11JAN2014 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -432,7 +432,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1275 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 07FEB2014 / 11:59 \cell
+\pard\intbl\qc\fs16 07FEB2014 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -454,7 +454,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1287 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 25JAN2014 / 11:59 \cell
+\pard\intbl\qc\fs16 25JAN2014 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -476,7 +476,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1294 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 24MAR2013 / 11:59 \cell
+\pard\intbl\qc\fs16 24MAR2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -498,7 +498,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1302 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 29AUG2013 / 11:59 \cell
+\pard\intbl\qc\fs16 29AUG2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -520,7 +520,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1317 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 22MAY2014 / 11:59 \cell
+\pard\intbl\qc\fs16 22MAY2014 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -542,7 +542,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1324 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 02OCT2012 / 11:59 \cell
+\pard\intbl\qc\fs16 02OCT2012 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -564,7 +564,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1341 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 05JAN2013 / 11:59 \cell
+\pard\intbl\qc\fs16 05JAN2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -586,7 +586,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1345 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 08OCT2013 / 11:59 \cell
+\pard\intbl\qc\fs16 08OCT2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -608,7 +608,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1360 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 31JUL2013 / 11:59 \cell
+\pard\intbl\qc\fs16 31JUL2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -630,7 +630,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1363 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 30MAY2013 / 11:59 \cell
+\pard\intbl\qc\fs16 30MAY2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -652,7 +652,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1383 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 04FEB2013 / 11:59 \cell
+\pard\intbl\qc\fs16 04FEB2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -674,7 +674,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1387 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 12MAR2014 / 11:59 \cell
+\pard\intbl\qc\fs16 12MAR2014 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -696,7 +696,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1392 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 28OCT2012 / 11:59 \cell
+\pard\intbl\qc\fs16 28OCT2012 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -718,7 +718,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1415 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 23SEP2013 / 11:59 \cell
+\pard\intbl\qc\fs16 23SEP2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -740,7 +740,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1429 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 19MAR2013 / 11:59 \cell
+\pard\intbl\qc\fs16 19MAR2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -762,7 +762,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1440 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 08AUG2013 / 11:59 \cell
+\pard\intbl\qc\fs16 08AUG2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -784,7 +784,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1442 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 26OCT2013 / 11:59 \cell
+\pard\intbl\qc\fs16 26OCT2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -806,7 +806,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1444 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 05JAN2013 / 11:59 \cell
+\pard\intbl\qc\fs16 05JAN2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -828,7 +828,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-702-1082 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 26JUL2013 / 11:59 \cell
+\pard\intbl\qc\fs16 26JUL2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -850,7 +850,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1076 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 25OCT2013 / 11:59 \cell
+\pard\intbl\qc\fs16 25OCT2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -872,7 +872,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1096 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 25JAN2013 / 11:59 \cell
+\pard\intbl\qc\fs16 25JAN2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -894,7 +894,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1100 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 13MAR2013 / 11:59 \cell
+\pard\intbl\qc\fs16 13MAR2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -916,7 +916,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1119 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 20FEB2013 / 11:59 \cell
+\pard\intbl\qc\fs16 20FEB2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -938,7 +938,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1175 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 20DEC2013 / 11:59 \cell
+\pard\intbl\qc\fs16 20DEC2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -960,7 +960,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1182 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 17OCT2013 / 11:59 \cell
+\pard\intbl\qc\fs16 17OCT2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -982,7 +982,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1197 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 16JUN2013 / 11:59 \cell
+\pard\intbl\qc\fs16 16JUN2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1004,7 +1004,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1210 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 16MAR2013 / 11:59 \cell
+\pard\intbl\qc\fs16 16MAR2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1026,7 +1026,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1258 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 20JUL2012 / 11:59 \cell
+\pard\intbl\qc\fs16 20JUL2012 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1048,7 +1048,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1279 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 13MAY2013 / 11:59 \cell
+\pard\intbl\qc\fs16 13MAY2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1070,7 +1070,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1299 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 12SEP2012 / 11:59 \cell
+\pard\intbl\qc\fs16 12SEP2012 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1092,7 +1092,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1335 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 17MAR2014 / 11:59 \cell
+\pard\intbl\qc\fs16 17MAR2014 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1114,7 +1114,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1379 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 22SEP2013 / 11:59 \cell
+\pard\intbl\qc\fs16 22SEP2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1136,7 +1136,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1403 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 12DEC2012 / 11:59 \cell
+\pard\intbl\qc\fs16 12DEC2012 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1158,7 +1158,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1008 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 13JAN2013 / 11:59 \cell
+\pard\intbl\qc\fs16 13JAN2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1180,7 +1180,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1009 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 27AUG2013 / 11:59 \cell
+\pard\intbl\qc\fs16 27AUG2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1202,7 +1202,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1017 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 06OCT2013 / 11:59 \cell
+\pard\intbl\qc\fs16 06OCT2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1224,7 +1224,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1025 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 27SEP2013 / 11:59 \cell
+\pard\intbl\qc\fs16 27SEP2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1246,7 +1246,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1065 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 24OCT2013 / 11:59 \cell
+\pard\intbl\qc\fs16 24OCT2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1268,7 +1268,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1074 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 22JAN2014 / 11:59 \cell
+\pard\intbl\qc\fs16 22JAN2014 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1290,7 +1290,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1093 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 15MAR2013 / 11:59 \cell
+\pard\intbl\qc\fs16 15MAR2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1312,7 +1312,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1114 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 23JAN2013 / 11:59 \cell
+\pard\intbl\qc\fs16 23JAN2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1334,7 +1334,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1120 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 02DEC2013 / 11:59 \cell
+\pard\intbl\qc\fs16 02DEC2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1356,7 +1356,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1127 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 02OCT2013 / 11:59 \cell
+\pard\intbl\qc\fs16 02OCT2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1378,7 +1378,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1135 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 31OCT2013 / 11:59 \cell
+\pard\intbl\qc\fs16 31OCT2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1400,7 +1400,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1164 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 19SEP2012 / 11:59 \cell
+\pard\intbl\qc\fs16 19SEP2012 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1422,7 +1422,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1218 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 19NOV2012 / 11:59 \cell
+\pard\intbl\qc\fs16 19NOV2012 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1444,7 +1444,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1233 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 21MAR2013 / 11:59 \cell
+\pard\intbl\qc\fs16 21MAR2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1466,7 +1466,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1260 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 30AUG2012 / 11:59 \cell
+\pard\intbl\qc\fs16 30AUG2012 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1488,7 +1488,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1266 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 13OCT2013 / 11:59 \cell
+\pard\intbl\qc\fs16 13OCT2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1510,7 +1510,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1325 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 23APR2014 / 11:59 \cell
+\pard\intbl\qc\fs16 23APR2014 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1532,7 +1532,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1388 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 07DEC2012 / 11:59 \cell
+\pard\intbl\qc\fs16 07DEC2012 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1554,7 +1554,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1435 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 17NOV2012 / 11:59 \cell
+\pard\intbl\qc\fs16 17NOV2012 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1576,7 +1576,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1059 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 05AUG2013 / 11:59 \cell
+\pard\intbl\qc\fs16 05AUG2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1598,7 +1598,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1199 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 16SEP2013 / 11:59 \cell
+\pard\intbl\qc\fs16 16SEP2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1620,7 +1620,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1280 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 17JAN2014 / 11:59 \cell
+\pard\intbl\qc\fs16 17JAN2014 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1642,7 +1642,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1281 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 28NOV2013 / 11:59 \cell
+\pard\intbl\qc\fs16 28NOV2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1664,7 +1664,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1282 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 26DEC2012 / 11:59 \cell
+\pard\intbl\qc\fs16 26DEC2012 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1686,7 +1686,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1292 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 14OCT2013 / 11:59 \cell
+\pard\intbl\qc\fs16 14OCT2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1708,7 +1708,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1303 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 16DEC2013 / 11:59 \cell
+\pard\intbl\qc\fs16 16DEC2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1730,7 +1730,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1310 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 02NOV2013 / 11:59 \cell
+\pard\intbl\qc\fs16 02NOV2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1752,7 +1752,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1382 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 13MAY2013 / 11:59 \cell
+\pard\intbl\qc\fs16 13MAY2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1774,7 +1774,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1393 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 07SEP2012 / 11:59 \cell
+\pard\intbl\qc\fs16 07SEP2012 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1796,7 +1796,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-706-1384 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 15SEP2012 / 11:59 \cell
+\pard\intbl\qc\fs16 15SEP2012 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1818,7 +1818,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-707-1206 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 28OCT2013 / 11:59 \cell
+\pard\intbl\qc\fs16 28OCT2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1840,7 +1840,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1019 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 20DEC2013 / 11:59 \cell
+\pard\intbl\qc\fs16 20DEC2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1862,7 +1862,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1032 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 09FEB2013 / 11:59 \cell
+\pard\intbl\qc\fs16 09FEB2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1884,7 +1884,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1213 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 09FEB2013 / 11:59 \cell
+\pard\intbl\qc\fs16 09FEB2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1906,7 +1906,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1216 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 24OCT2012 / 11:59 \cell
+\pard\intbl\qc\fs16 24OCT2012 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1928,7 +1928,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1236 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 21SEP2013 / 11:59 \cell
+\pard\intbl\qc\fs16 21SEP2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1950,7 +1950,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1272 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 06FEB2013 / 11:59 \cell
+\pard\intbl\qc\fs16 06FEB2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1972,7 +1972,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1286 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 10SEP2013 / 11:59 \cell
+\pard\intbl\qc\fs16 10SEP2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1994,7 +1994,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1297 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 25JAN2013 / 11:59 \cell
+\pard\intbl\qc\fs16 25JAN2013 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2016,7 +2016,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1316 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 23AUG2013 / 11:59 \cell
+\pard\intbl\qc\fs16 23AUG2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2038,7 +2038,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1336 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 07DEC2012 / 11:59 \cell
+\pard\intbl\qc\fs16 07DEC2012 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2060,7 +2060,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1342 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 29DEC2012 / 11:59 \cell
+\pard\intbl\qc\fs16 29DEC2012 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2082,7 +2082,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1347 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 20APR2013 / 11:59 \cell
+\pard\intbl\qc\fs16 20APR2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2104,7 +2104,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1348 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 05AUG2013 / 11:59 \cell
+\pard\intbl\qc\fs16 05AUG2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2126,7 +2126,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1353 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 04JUL2013 / 11:59 \cell
+\pard\intbl\qc\fs16 04JUL2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2148,7 +2148,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1372 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 12APR2013 / 11:59 \cell
+\pard\intbl\qc\fs16 12APR2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2170,7 +2170,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1378 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 03SEP2013 / 11:59 \cell
+\pard\intbl\qc\fs16 03SEP2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2192,7 +2192,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-709-1001 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 08OCT2013 / 11:59 \cell
+\pard\intbl\qc\fs16 08OCT2013 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2214,7 +2214,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-709-1081 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 18JAN2014 / 11:59 \cell
+\pard\intbl\qc\fs16 18JAN2014 / 12:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2236,7 +2236,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-709-1088 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 12APR2014 / 11:59 \cell
+\pard\intbl\qc\fs16 12APR2014 / 13:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell

--- a/tests/testthat/_snaps/lsidem02/lsidem02.rtf
+++ b/tests/testthat/_snaps/lsidem02/lsidem02.rtf
@@ -58,7 +58,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1023 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 05AUG2012 / 13:59 \cell
+\pard\intbl\qc\fs16 05AUG2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -80,7 +80,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1028 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 19JUL2013 / 13:59 \cell
+\pard\intbl\qc\fs16 19JUL2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -102,7 +102,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1033 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 18MAR2014 / 12:59 \cell
+\pard\intbl\qc\fs16 18MAR2014 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -124,7 +124,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1034 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 01JUL2014 / 13:59 \cell
+\pard\intbl\qc\fs16 01JUL2014 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -146,7 +146,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1047 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 12FEB2013 / 12:59 \cell
+\pard\intbl\qc\fs16 12FEB2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -168,7 +168,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1111 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 07SEP2012 / 13:59 \cell
+\pard\intbl\qc\fs16 07SEP2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -190,7 +190,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1115 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 30NOV2012 / 12:59 \cell
+\pard\intbl\qc\fs16 30NOV2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -212,7 +212,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1118 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 12MAR2014 / 12:59 \cell
+\pard\intbl\qc\fs16 12MAR2014 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -234,7 +234,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1130 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 15FEB2014 / 12:59 \cell
+\pard\intbl\qc\fs16 15FEB2014 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -256,7 +256,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1146 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 20MAY2013 / 13:59 \cell
+\pard\intbl\qc\fs16 20MAY2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -278,7 +278,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1148 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 23AUG2013 / 13:59 \cell
+\pard\intbl\qc\fs16 23AUG2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -300,7 +300,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1181 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 05DEC2013 / 12:59 \cell
+\pard\intbl\qc\fs16 05DEC2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -322,7 +322,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1188 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 15FEB2013 / 12:59 \cell
+\pard\intbl\qc\fs16 15FEB2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -344,7 +344,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1192 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 22JUL2012 / 13:59 \cell
+\pard\intbl\qc\fs16 22JUL2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -366,7 +366,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1203 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 02FEB2013 / 12:59 \cell
+\pard\intbl\qc\fs16 02FEB2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -388,7 +388,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1211 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 15NOV2012 / 12:59 \cell
+\pard\intbl\qc\fs16 15NOV2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -410,7 +410,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1239 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 11JAN2014 / 12:59 \cell
+\pard\intbl\qc\fs16 11JAN2014 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -432,7 +432,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1275 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 07FEB2014 / 12:59 \cell
+\pard\intbl\qc\fs16 07FEB2014 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -454,7 +454,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1287 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 25JAN2014 / 12:59 \cell
+\pard\intbl\qc\fs16 25JAN2014 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -476,7 +476,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1294 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 24MAR2013 / 12:59 \cell
+\pard\intbl\qc\fs16 24MAR2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -498,7 +498,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1302 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 29AUG2013 / 13:59 \cell
+\pard\intbl\qc\fs16 29AUG2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -520,7 +520,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1317 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 22MAY2014 / 13:59 \cell
+\pard\intbl\qc\fs16 22MAY2014 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -542,7 +542,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1324 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 02OCT2012 / 13:59 \cell
+\pard\intbl\qc\fs16 02OCT2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -564,7 +564,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1341 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 05JAN2013 / 12:59 \cell
+\pard\intbl\qc\fs16 05JAN2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -586,7 +586,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1345 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 08OCT2013 / 13:59 \cell
+\pard\intbl\qc\fs16 08OCT2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -608,7 +608,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1360 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 31JUL2013 / 13:59 \cell
+\pard\intbl\qc\fs16 31JUL2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -630,7 +630,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1363 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 30MAY2013 / 13:59 \cell
+\pard\intbl\qc\fs16 30MAY2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -652,7 +652,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1383 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 04FEB2013 / 12:59 \cell
+\pard\intbl\qc\fs16 04FEB2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -674,7 +674,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1387 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 12MAR2014 / 12:59 \cell
+\pard\intbl\qc\fs16 12MAR2014 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -696,7 +696,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1392 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 28OCT2012 / 12:59 \cell
+\pard\intbl\qc\fs16 28OCT2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -718,7 +718,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1415 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 23SEP2013 / 13:59 \cell
+\pard\intbl\qc\fs16 23SEP2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -740,7 +740,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1429 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 19MAR2013 / 12:59 \cell
+\pard\intbl\qc\fs16 19MAR2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -762,7 +762,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1440 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 08AUG2013 / 13:59 \cell
+\pard\intbl\qc\fs16 08AUG2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -784,7 +784,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1442 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 26OCT2013 / 13:59 \cell
+\pard\intbl\qc\fs16 26OCT2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -806,7 +806,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-701-1444 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 05JAN2013 / 12:59 \cell
+\pard\intbl\qc\fs16 05JAN2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -828,7 +828,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-702-1082 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 26JUL2013 / 13:59 \cell
+\pard\intbl\qc\fs16 26JUL2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -850,7 +850,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1076 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 25OCT2013 / 13:59 \cell
+\pard\intbl\qc\fs16 25OCT2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -872,7 +872,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1096 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 25JAN2013 / 12:59 \cell
+\pard\intbl\qc\fs16 25JAN2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -894,7 +894,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1100 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 13MAR2013 / 12:59 \cell
+\pard\intbl\qc\fs16 13MAR2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -916,7 +916,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1119 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 20FEB2013 / 12:59 \cell
+\pard\intbl\qc\fs16 20FEB2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -938,7 +938,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1175 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 20DEC2013 / 12:59 \cell
+\pard\intbl\qc\fs16 20DEC2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -960,7 +960,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1182 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 17OCT2013 / 13:59 \cell
+\pard\intbl\qc\fs16 17OCT2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -982,7 +982,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1197 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 16JUN2013 / 13:59 \cell
+\pard\intbl\qc\fs16 16JUN2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1004,7 +1004,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1210 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 16MAR2013 / 12:59 \cell
+\pard\intbl\qc\fs16 16MAR2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1026,7 +1026,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1258 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 20JUL2012 / 13:59 \cell
+\pard\intbl\qc\fs16 20JUL2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1048,7 +1048,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1279 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 13MAY2013 / 13:59 \cell
+\pard\intbl\qc\fs16 13MAY2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1070,7 +1070,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1299 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 12SEP2012 / 13:59 \cell
+\pard\intbl\qc\fs16 12SEP2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1092,7 +1092,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1335 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 17MAR2014 / 12:59 \cell
+\pard\intbl\qc\fs16 17MAR2014 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1114,7 +1114,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1379 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 22SEP2013 / 13:59 \cell
+\pard\intbl\qc\fs16 22SEP2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1136,7 +1136,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-703-1403 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 12DEC2012 / 12:59 \cell
+\pard\intbl\qc\fs16 12DEC2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1158,7 +1158,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1008 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 13JAN2013 / 12:59 \cell
+\pard\intbl\qc\fs16 13JAN2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1180,7 +1180,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1009 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 27AUG2013 / 13:59 \cell
+\pard\intbl\qc\fs16 27AUG2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1202,7 +1202,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1017 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 06OCT2013 / 13:59 \cell
+\pard\intbl\qc\fs16 06OCT2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1224,7 +1224,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1025 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 27SEP2013 / 13:59 \cell
+\pard\intbl\qc\fs16 27SEP2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1246,7 +1246,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1065 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 24OCT2013 / 13:59 \cell
+\pard\intbl\qc\fs16 24OCT2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1268,7 +1268,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1074 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 22JAN2014 / 12:59 \cell
+\pard\intbl\qc\fs16 22JAN2014 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1290,7 +1290,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1093 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 15MAR2013 / 12:59 \cell
+\pard\intbl\qc\fs16 15MAR2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1312,7 +1312,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1114 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 23JAN2013 / 12:59 \cell
+\pard\intbl\qc\fs16 23JAN2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1334,7 +1334,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1120 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 02DEC2013 / 12:59 \cell
+\pard\intbl\qc\fs16 02DEC2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1356,7 +1356,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1127 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 02OCT2013 / 13:59 \cell
+\pard\intbl\qc\fs16 02OCT2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1378,7 +1378,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1135 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 31OCT2013 / 12:59 \cell
+\pard\intbl\qc\fs16 31OCT2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1400,7 +1400,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1164 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 19SEP2012 / 13:59 \cell
+\pard\intbl\qc\fs16 19SEP2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1422,7 +1422,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1218 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 19NOV2012 / 12:59 \cell
+\pard\intbl\qc\fs16 19NOV2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1444,7 +1444,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1233 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 21MAR2013 / 12:59 \cell
+\pard\intbl\qc\fs16 21MAR2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1466,7 +1466,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1260 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 30AUG2012 / 13:59 \cell
+\pard\intbl\qc\fs16 30AUG2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1488,7 +1488,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1266 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 13OCT2013 / 13:59 \cell
+\pard\intbl\qc\fs16 13OCT2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1510,7 +1510,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1325 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 23APR2014 / 13:59 \cell
+\pard\intbl\qc\fs16 23APR2014 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1532,7 +1532,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1388 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 07DEC2012 / 12:59 \cell
+\pard\intbl\qc\fs16 07DEC2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1554,7 +1554,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-704-1435 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 17NOV2012 / 12:59 \cell
+\pard\intbl\qc\fs16 17NOV2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1576,7 +1576,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1059 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 05AUG2013 / 13:59 \cell
+\pard\intbl\qc\fs16 05AUG2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1598,7 +1598,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1199 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 16SEP2013 / 13:59 \cell
+\pard\intbl\qc\fs16 16SEP2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1620,7 +1620,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1280 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 17JAN2014 / 12:59 \cell
+\pard\intbl\qc\fs16 17JAN2014 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1642,7 +1642,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1281 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 28NOV2013 / 12:59 \cell
+\pard\intbl\qc\fs16 28NOV2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1664,7 +1664,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1282 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 26DEC2012 / 12:59 \cell
+\pard\intbl\qc\fs16 26DEC2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1686,7 +1686,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1292 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 14OCT2013 / 13:59 \cell
+\pard\intbl\qc\fs16 14OCT2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1708,7 +1708,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1303 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 16DEC2013 / 12:59 \cell
+\pard\intbl\qc\fs16 16DEC2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1730,7 +1730,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1310 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 02NOV2013 / 12:59 \cell
+\pard\intbl\qc\fs16 02NOV2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1752,7 +1752,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1382 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 13MAY2013 / 13:59 \cell
+\pard\intbl\qc\fs16 13MAY2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1774,7 +1774,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-705-1393 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 07SEP2012 / 13:59 \cell
+\pard\intbl\qc\fs16 07SEP2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1796,7 +1796,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-706-1384 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 15SEP2012 / 13:59 \cell
+\pard\intbl\qc\fs16 15SEP2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1818,7 +1818,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-707-1206 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 28OCT2013 / 12:59 \cell
+\pard\intbl\qc\fs16 28OCT2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1840,7 +1840,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1019 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 20DEC2013 / 12:59 \cell
+\pard\intbl\qc\fs16 20DEC2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1862,7 +1862,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1032 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 09FEB2013 / 12:59 \cell
+\pard\intbl\qc\fs16 09FEB2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1884,7 +1884,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1213 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 09FEB2013 / 12:59 \cell
+\pard\intbl\qc\fs16 09FEB2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1906,7 +1906,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1216 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 24OCT2012 / 13:59 \cell
+\pard\intbl\qc\fs16 24OCT2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1928,7 +1928,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1236 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 21SEP2013 / 13:59 \cell
+\pard\intbl\qc\fs16 21SEP2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1950,7 +1950,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1272 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 06FEB2013 / 12:59 \cell
+\pard\intbl\qc\fs16 06FEB2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1972,7 +1972,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1286 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 10SEP2013 / 13:59 \cell
+\pard\intbl\qc\fs16 10SEP2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -1994,7 +1994,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1297 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 25JAN2013 / 12:59 \cell
+\pard\intbl\qc\fs16 25JAN2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2016,7 +2016,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1316 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 23AUG2013 / 13:59 \cell
+\pard\intbl\qc\fs16 23AUG2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2038,7 +2038,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1336 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 07DEC2012 / 12:59 \cell
+\pard\intbl\qc\fs16 07DEC2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2060,7 +2060,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1342 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 29DEC2012 / 12:59 \cell
+\pard\intbl\qc\fs16 29DEC2012 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2082,7 +2082,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1347 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 20APR2013 / 13:59 \cell
+\pard\intbl\qc\fs16 20APR2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2104,7 +2104,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1348 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 05AUG2013 / 13:59 \cell
+\pard\intbl\qc\fs16 05AUG2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2126,7 +2126,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1353 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 04JUL2013 / 13:59 \cell
+\pard\intbl\qc\fs16 04JUL2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2148,7 +2148,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1372 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 12APR2013 / 13:59 \cell
+\pard\intbl\qc\fs16 12APR2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2170,7 +2170,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-708-1378 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 03SEP2013 / 13:59 \cell
+\pard\intbl\qc\fs16 03SEP2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2192,7 +2192,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-709-1001 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 08OCT2013 / 13:59 \cell
+\pard\intbl\qc\fs16 08OCT2013 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2214,7 +2214,7 @@
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-709-1081 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 18JAN2014 / 12:59 \cell
+\pard\intbl\qc\fs16 18JAN2014 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell
@@ -2236,7 +2236,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\brdrcf1\clbrdrr\clvertalt\cellx12701 \pard\intbl\ql\fs16 01-709-1088 \cell
 \pard\intbl\qc\fs16 NA \cell
 \pard\intbl\qc\fs16 United States of America \cell
-\pard\intbl\qc\fs16 12APR2014 / 13:59 \cell
+\pard\intbl\qc\fs16 12APR2014 / 11:59 \cell
 \pard\intbl\qc\fs16 1000001 \cell
 \pard\intbl\qc\fs16 Stratification Factor 1 \cell
 \pard\intbl\qc\fs16 Stratification Factor 2 \cell

--- a/tests/testthat/_snaps/tsfae02/tsfae02.rtf
+++ b/tests/testthat/_snaps/tsfae02/tsfae02.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7108 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8490 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10530 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae02a/tsfae02a.rtf
+++ b/tests/testthat/_snaps/tsfae02a/tsfae02a.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7008 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8322 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10512 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae03/tsfae03.rtf
+++ b/tests/testthat/_snaps/tsfae03/tsfae03.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7094 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8513 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10607 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae03a/tsfae03a.rtf
+++ b/tests/testthat/_snaps/tsfae03a/tsfae03a.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6864 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8211 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10456 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae04/tsfae04.rtf
+++ b/tests/testthat/_snaps/tsfae04/tsfae04.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7140 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8582 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10573 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae04a/tsfae04a.rtf
+++ b/tests/testthat/_snaps/tsfae04a/tsfae04a.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7041 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8353 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10561 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae05/tsfae05.rtf
+++ b/tests/testthat/_snaps/tsfae05/tsfae05.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7140 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8445 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10573 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae05a/tsfae05a.rtf
+++ b/tests/testthat/_snaps/tsfae05a/tsfae05a.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6996 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8287 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10460 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae08/tsfae08.rtf
+++ b/tests/testthat/_snaps/tsfae08/tsfae08.rtf
@@ -49,7 +49,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4444 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6026 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7608 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae11/tsfae11.rtf
+++ b/tests/testthat/_snaps/tsfae11/tsfae11.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7049 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8446 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10507 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae12/tsfae12.rtf
+++ b/tests/testthat/_snaps/tsfae12/tsfae12.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7132 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8558 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10596 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae14/tsfae14.rtf
+++ b/tests/testthat/_snaps/tsfae14/tsfae14.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7094 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8513 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10607 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   OCMQ (Narrow), n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 OCMQ (Narrow), n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae15/tsfae15.rtf
+++ b/tests/testthat/_snaps/tsfae15/tsfae15.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6968 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8202 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10451 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   OCMQ (Narrow), n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 OCMQ (Narrow), n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae16part1/tsfae16part1of2.rtf
+++ b/tests/testthat/_snaps/tsfae16part1/tsfae16part1of2.rtf
@@ -99,7 +99,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9435 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10524 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx11613 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   OCMQ, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 OCMQ, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=59 \cell

--- a/tests/testthat/_snaps/tsfae16part2/tsfae16part2of2.rtf
+++ b/tests/testthat/_snaps/tsfae16part2/tsfae16part2of2.rtf
@@ -45,7 +45,7 @@
 \trowd
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2774 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7592 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   OCMQ, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 OCMQ, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \row

--- a/tests/testthat/_snaps/tsfae17a/tsfae17a.rtf
+++ b/tests/testthat/_snaps/tsfae17a/tsfae17a.rtf
@@ -45,7 +45,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx6821 
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx8154 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx10428 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   OCMQ (Narrow) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 OCMQ (Narrow) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline High Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline Low Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Combined \cell
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6821 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8154 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10428 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr     Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li360\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae17b/tsfae17b.rtf
+++ b/tests/testthat/_snaps/tsfae17b/tsfae17b.rtf
@@ -45,7 +45,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx6821 
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx8154 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx10428 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   OCMQ (Narrow) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 OCMQ (Narrow) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline High Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline Low Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Combined \cell
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6821 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8154 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10428 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr     Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li360\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae17c/tsfae17c.rtf
+++ b/tests/testthat/_snaps/tsfae17c/tsfae17c.rtf
@@ -45,7 +45,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx6821 
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx8154 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx10428 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   OCMQ (Narrow) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 OCMQ (Narrow) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline High Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline Low Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Combined \cell
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6821 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8154 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10428 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr     Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li360\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae17d/tsfae17d.rtf
+++ b/tests/testthat/_snaps/tsfae17d/tsfae17d.rtf
@@ -45,7 +45,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx6821 
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx8154 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx10428 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   OCMQ (Broad) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 OCMQ (Broad) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline High Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline Low Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Combined \cell
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6821 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8154 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10428 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr     Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li360\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae19a/tsfae19a.rtf
+++ b/tests/testthat/_snaps/tsfae19a/tsfae19a.rtf
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4983 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6644 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9673 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=29 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=34 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=23 \cell

--- a/tests/testthat/_snaps/tsfae19b/tsfae19b.rtf
+++ b/tests/testthat/_snaps/tsfae19b/tsfae19b.rtf
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx3900 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5794 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9248 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=29 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=34 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=23 \cell

--- a/tests/testthat/_snaps/tsfae19c/tsfae19c.rtf
+++ b/tests/testthat/_snaps/tsfae19c/tsfae19c.rtf
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5534 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6162 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9683 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=24 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=39 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=36 \cell

--- a/tests/testthat/_snaps/tsfae19d/tsfae19d.rtf
+++ b/tests/testthat/_snaps/tsfae19d/tsfae19d.rtf
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5081 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6808 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9755 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=24 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=39 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=36 \cell

--- a/tests/testthat/_snaps/tsfae21apart1/tsfae21apart1of4.rtf
+++ b/tests/testthat/_snaps/tsfae21apart1/tsfae21apart1of4.rtf
@@ -66,7 +66,7 @@
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2828 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4948 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7069 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mild \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Moderate \cell

--- a/tests/testthat/_snaps/tsfae21apart2/tsfae21apart2of4.rtf
+++ b/tests/testthat/_snaps/tsfae21apart2/tsfae21apart2of4.rtf
@@ -77,7 +77,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4516 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6179 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7843 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mild \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Moderate \cell

--- a/tests/testthat/_snaps/tsfae21apart3/tsfae21apart3of4.rtf
+++ b/tests/testthat/_snaps/tsfae21apart3/tsfae21apart3of4.rtf
@@ -77,7 +77,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4634 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6255 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7877 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mild \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Moderate \cell

--- a/tests/testthat/_snaps/tsfae21apart4/tsfae21apart4of4.rtf
+++ b/tests/testthat/_snaps/tsfae21apart4/tsfae21apart4of4.rtf
@@ -77,7 +77,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4554 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6262 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7807 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mild \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Moderate \cell

--- a/tests/testthat/_snaps/tsfae21bpart1/tsfae21bpart1of4.rtf
+++ b/tests/testthat/_snaps/tsfae21bpart1/tsfae21bpart1of4.rtf
@@ -99,7 +99,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7672 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9121 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10911 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr 1 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr 2 \cell

--- a/tests/testthat/_snaps/tsfae21bpart2/tsfae21bpart2of4.rtf
+++ b/tests/testthat/_snaps/tsfae21bpart2/tsfae21bpart2of4.rtf
@@ -99,7 +99,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7674 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9173 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx11025 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr 1 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr 2 \cell

--- a/tests/testthat/_snaps/tsfae21bpart3/tsfae21bpart3of4.rtf
+++ b/tests/testthat/_snaps/tsfae21bpart3/tsfae21bpart3of4.rtf
@@ -99,7 +99,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7771 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9192 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10947 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr 1 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr 2 \cell

--- a/tests/testthat/_snaps/tsfae21bpart4/tsfae21bpart4of4.rtf
+++ b/tests/testthat/_snaps/tsfae21bpart4/tsfae21bpart4of4.rtf
@@ -99,7 +99,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7938 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9526 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx11114 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr 1 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr 2 \cell

--- a/tests/testthat/_snaps/tsfae21c/tsfae21c.rtf
+++ b/tests/testthat/_snaps/tsfae21c/tsfae21c.rtf
@@ -49,7 +49,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx3857 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5579 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7466 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae21d/tsfae21d.rtf
+++ b/tests/testthat/_snaps/tsfae21d/tsfae21d.rtf
@@ -49,7 +49,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx3857 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5579 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7466 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfae22apart1/tsfae22apart1of4.rtf
+++ b/tests/testthat/_snaps/tsfae22apart1/tsfae22apart1of4.rtf
@@ -72,7 +72,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4892 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6281 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7801 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr White \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Black \cell

--- a/tests/testthat/_snaps/tsfae22apart2/tsfae22apart2of4.rtf
+++ b/tests/testthat/_snaps/tsfae22apart2/tsfae22apart2of4.rtf
@@ -72,7 +72,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4987 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6340 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7693 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr White \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Black \cell

--- a/tests/testthat/_snaps/tsfae22apart3/tsfae22apart3of4.rtf
+++ b/tests/testthat/_snaps/tsfae22apart3/tsfae22apart3of4.rtf
@@ -72,7 +72,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5006 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6309 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7749 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr White \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Black \cell

--- a/tests/testthat/_snaps/tsfae22apart4/tsfae22apart4of4.rtf
+++ b/tests/testthat/_snaps/tsfae22apart4/tsfae22apart4of4.rtf
@@ -72,7 +72,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4987 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6340 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7693 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr White \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Black \cell

--- a/tests/testthat/_snaps/tsfae22bpart1/tsfae22bpart1of2.rtf
+++ b/tests/testthat/_snaps/tsfae22bpart1/tsfae22bpart1of2.rtf
@@ -81,7 +81,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5659 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6836 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8013 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Male \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Female \cell

--- a/tests/testthat/_snaps/tsfae22bpart2/tsfae22bpart2of2.rtf
+++ b/tests/testthat/_snaps/tsfae22bpart2/tsfae22bpart2of2.rtf
@@ -81,7 +81,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5723 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6878 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8034 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Male \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Female \cell

--- a/tests/testthat/_snaps/tsfae22cpart1/tsfae22cpart1of4.rtf
+++ b/tests/testthat/_snaps/tsfae22cpart1/tsfae22cpart1of4.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx3857 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5579 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7302 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr \u8805?18 to <65 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr \u8805?65 to <75 \cell

--- a/tests/testthat/_snaps/tsfae22cpart2/tsfae22cpart2of4.rtf
+++ b/tests/testthat/_snaps/tsfae22cpart2/tsfae22cpart2of4.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx3878 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5649 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7419 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr \u8805?18 to <65 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr \u8805?65 to <75 \cell

--- a/tests/testthat/_snaps/tsfae22cpart3/tsfae22cpart3of4.rtf
+++ b/tests/testthat/_snaps/tsfae22cpart3/tsfae22cpart3of4.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx3996 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5833 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7511 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr \u8805?18 to <65 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr \u8805?65 to <75 \cell

--- a/tests/testthat/_snaps/tsfae22cpart4/tsfae22cpart4of4.rtf
+++ b/tests/testthat/_snaps/tsfae22cpart4/tsfae22cpart4of4.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx3951 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5582 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7386 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr \u8805?18 to <65 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr \u8805?65 to <75 \cell

--- a/tests/testthat/_snaps/tsfae24c/tsfae24c.rtf
+++ b/tests/testthat/_snaps/tsfae24c/tsfae24c.rtf
@@ -81,7 +81,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7859 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9526 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx11193 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr  Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=59 \cell

--- a/tests/testthat/_snaps/tsfae24d/tsfae24d.rtf
+++ b/tests/testthat/_snaps/tsfae24d/tsfae24d.rtf
@@ -99,7 +99,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9048 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10266 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx11483 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr  Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr AEs \cell
 \pard\intbl\qc\fs18 \keepn\trhdr \u8805? Grade 3 AEs \cell
 \pard\intbl\qc\fs18 \keepn\trhdr AEs \cell

--- a/tests/testthat/_snaps/tsfae24fpart1/tsfae24fpart1of3.rtf
+++ b/tests/testthat/_snaps/tsfae24fpart1/tsfae24fpart1of3.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7605 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9142 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10841 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Within 3 months \cell
 \pard\intbl\qc\fs18 \keepn\trhdr 4 to 6 months \cell

--- a/tests/testthat/_snaps/tsfae24fpart2/tsfae24fpart2of3.rtf
+++ b/tests/testthat/_snaps/tsfae24fpart2/tsfae24fpart2of3.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7859 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9526 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx11193 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Within 3 months \cell
 \pard\intbl\qc\fs18 \keepn\trhdr 4 to 6 months \cell

--- a/tests/testthat/_snaps/tsfae24fpart3/tsfae24fpart3of3.rtf
+++ b/tests/testthat/_snaps/tsfae24fpart3/tsfae24fpart3of3.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7672 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9292 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx11082 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Total \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Within 3 months \cell
 \pard\intbl\qc\fs18 \keepn\trhdr 4 to 6 months \cell

--- a/tests/testthat/_snaps/tsfdth01/tsfdth01.rtf
+++ b/tests/testthat/_snaps/tsfdth01/tsfdth01.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6221 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7690 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10196 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Cause of Death, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Cause of Death, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsfecg01apart1/tsfecg01apart1of3.rtf
+++ b/tests/testthat/_snaps/tsfecg01apart1/tsfecg01apart1of3.rtf
@@ -54,7 +54,7 @@
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2802 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5510 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8872 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr n/N (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean (95% CI) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean Change From Baseline (95% CI) \cell

--- a/tests/testthat/_snaps/tsfecg01apart2/tsfecg01apart2of3.rtf
+++ b/tests/testthat/_snaps/tsfecg01apart2/tsfecg01apart2of3.rtf
@@ -54,7 +54,7 @@
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2802 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5510 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8872 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr n/N (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean (95% CI) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean Change From Baseline (95% CI) \cell

--- a/tests/testthat/_snaps/tsfecg01apart3/tsfecg01apart3of3.rtf
+++ b/tests/testthat/_snaps/tsfecg01apart3/tsfecg01apart3of3.rtf
@@ -72,7 +72,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6246 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8398 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10550 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr n/N (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean (95% CI) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean Change From Baseline (95% CI) \cell

--- a/tests/testthat/_snaps/tsfecg01part1/tsfecg01part1of2.rtf
+++ b/tests/testthat/_snaps/tsfecg01part1/tsfecg01part1of2.rtf
@@ -81,7 +81,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7733 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9093 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10780 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr n/N (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean (95% CI) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean Change From Baseline (95% CI) \cell

--- a/tests/testthat/_snaps/tsfecg01part2/tsfecg01part2of2.rtf
+++ b/tests/testthat/_snaps/tsfecg01part2/tsfecg01part2of2.rtf
@@ -72,7 +72,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6324 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8307 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10504 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr n/N (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean (95% CI) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean Change From Baseline (95% CI) \cell

--- a/tests/testthat/_snaps/tsfecg02/tsfecg02.rtf
+++ b/tests/testthat/_snaps/tsfecg02/tsfecg02.rtf
@@ -30,7 +30,7 @@
 \trqc \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx2828 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx4948 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx7069 
-\clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline High Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline Low Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Placebo \cell
@@ -42,7 +42,7 @@
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2828 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4948 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7069 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr    Criteria, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li270\fi0 Criteria, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=59 \cell

--- a/tests/testthat/_snaps/tsfecg03/tsfecg03.rtf
+++ b/tests/testthat/_snaps/tsfecg03/tsfecg03.rtf
@@ -42,7 +42,7 @@
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2828 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4948 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7069 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr    Criteria, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li270\fi0 Criteria, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=59 \cell

--- a/tests/testthat/_snaps/tsfecg04/tsfecg04.rtf
+++ b/tests/testthat/_snaps/tsfecg04/tsfecg04.rtf
@@ -45,7 +45,7 @@
 \clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5978 
 \clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7048 
 \clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8119 
-\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Treatment Group \cell
+\clmrg\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Treatment Group \cell
 \pard\intbl\qc\fs18 \keepn\trhdr  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Baseline Corrected QT Interval \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Baseline Corrected QT Interval \cell
@@ -63,7 +63,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5978 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7048 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8119 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr     Criteria, n \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li360\fi0 Criteria, n \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N \cell
 \pard\intbl\qc\fs18 \keepn\trhdr \u8804?450 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr >450 to \u8804?480  \cell

--- a/tests/testthat/_snaps/tsfecg05/tsfecg05.rtf
+++ b/tests/testthat/_snaps/tsfecg05/tsfecg05.rtf
@@ -30,7 +30,7 @@
 \trqc \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx2849 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx4962 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx7076 
-\clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline High Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline Low Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Placebo \cell
@@ -42,7 +42,7 @@
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2849 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4962 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7076 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr     Criteria, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li360\fi0 Criteria, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=59 \cell

--- a/tests/testthat/_snaps/tsflab01apart1/tsflab01apart1of3.rtf
+++ b/tests/testthat/_snaps/tsflab01apart1/tsflab01apart1of3.rtf
@@ -54,7 +54,7 @@
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2832 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5178 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8899 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr n/N (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean (95% CI) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean Change From Baseline (95% CI) \cell

--- a/tests/testthat/_snaps/tsflab01apart2/tsflab01apart2of3.rtf
+++ b/tests/testthat/_snaps/tsflab01apart2/tsflab01apart2of3.rtf
@@ -54,7 +54,7 @@
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2832 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5178 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8899 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr n/N (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean (95% CI) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean Change From Baseline (95% CI) \cell

--- a/tests/testthat/_snaps/tsflab01apart3/tsflab01apart3of3.rtf
+++ b/tests/testthat/_snaps/tsflab01apart3/tsflab01apart3of3.rtf
@@ -72,7 +72,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6216 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8378 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10494 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr n/N (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean (95% CI) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean Change From Baseline (95% CI) \cell

--- a/tests/testthat/_snaps/tsflab01part1/tsflab01part1of2.rtf
+++ b/tests/testthat/_snaps/tsflab01part1/tsflab01part1of2.rtf
@@ -81,7 +81,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7774 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8921 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10705 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr n/N (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean (95% CI) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean Change From Baseline (95% CI) \cell

--- a/tests/testthat/_snaps/tsflab01part2/tsflab01part2of2.rtf
+++ b/tests/testthat/_snaps/tsflab01part2/tsflab01part2of2.rtf
@@ -72,7 +72,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6048 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8328 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10515 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr n/N (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean (95% CI) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean Change From Baseline (95% CI) \cell

--- a/tests/testthat/_snaps/tsflab02/tsflab02.rtf
+++ b/tests/testthat/_snaps/tsflab02/tsflab02.rtf
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6190 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7878 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10290 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Threshold Level, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Threshold Level, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=59 \cell

--- a/tests/testthat/_snaps/tsflab02a/tsflab02a.rtf
+++ b/tests/testthat/_snaps/tsflab02a/tsflab02a.rtf
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6013 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7441 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10071 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Threshold Level, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Threshold Level, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=59 \cell

--- a/tests/testthat/_snaps/tsflab02b/tsflab02b.rtf
+++ b/tests/testthat/_snaps/tsflab02b/tsflab02b.rtf
@@ -40,7 +40,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx5869 
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx7396 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx10049 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Laboratory Test \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Laboratory Test \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline High Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline Low Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Placebo \cell
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5869 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7396 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10049 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr     Threshold Level, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li360\fi0 Threshold Level, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=59 \cell

--- a/tests/testthat/_snaps/tsflab03/tsflab03.rtf
+++ b/tests/testthat/_snaps/tsflab03/tsflab03.rtf
@@ -40,7 +40,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx6013 
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx7591 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx10071 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Laboratory Test \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Laboratory Test \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline High Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline Low Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Placebo \cell
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6013 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7591 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10071 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr     Grade, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li360\fi0 Grade, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=59 \cell

--- a/tests/testthat/_snaps/tsflab03a/tsflab03a.rtf
+++ b/tests/testthat/_snaps/tsflab03a/tsflab03a.rtf
@@ -40,7 +40,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx5846 
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx7361 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx10031 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Laboratory Test \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Laboratory Test \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline High Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline Low Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Placebo \cell
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5846 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7361 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10031 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr     Grade, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li360\fi0 Grade, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=59 \cell

--- a/tests/testthat/_snaps/tsflab04a/tsflab04a.rtf
+++ b/tests/testthat/_snaps/tsflab04a/tsflab04a.rtf
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6319 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8059 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10316 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Laboratory Test \u8805? Level 2, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Laboratory Test \u8805? Level 2, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=59 \cell

--- a/tests/testthat/_snaps/tsflab04b/tsflab04b.rtf
+++ b/tests/testthat/_snaps/tsflab04b/tsflab04b.rtf
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6417 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8203 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10386 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Laboratory Test \u8805? Level 2, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Laboratory Test \u8805? Level 2, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=59 \cell

--- a/tests/testthat/_snaps/tsflab05/tsflab05.rtf
+++ b/tests/testthat/_snaps/tsflab05/tsflab05.rtf
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6417 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8203 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10386 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Laboratory Test \u8805? Grade 2, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Laboratory Test \u8805? Grade 2, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=59 \cell

--- a/tests/testthat/_snaps/tsflab06/tsflab06.rtf
+++ b/tests/testthat/_snaps/tsflab06/tsflab06.rtf
@@ -40,7 +40,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6668 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8891 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10479 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Low \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Normal \cell

--- a/tests/testthat/_snaps/tsflab07/tsflab07.rtf
+++ b/tests/testthat/_snaps/tsflab07/tsflab07.rtf
@@ -50,7 +50,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8549 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9770 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10992 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Laboratory Test \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Laboratory Test \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Grade 0 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Grade 1 \cell

--- a/tests/testthat/_snaps/tsfvit01apart1/tsfvit01apart1of4.rtf
+++ b/tests/testthat/_snaps/tsfvit01apart1/tsfvit01apart1of4.rtf
@@ -54,7 +54,7 @@
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2860 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4788 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8778 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr n/N (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean (95% CI) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean Change From Baseline (95% CI) \cell

--- a/tests/testthat/_snaps/tsfvit01apart2/tsfvit01apart2of4.rtf
+++ b/tests/testthat/_snaps/tsfvit01apart2/tsfvit01apart2of4.rtf
@@ -54,7 +54,7 @@
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2838 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4797 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8851 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr n/N (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean (95% CI) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean Change From Baseline (95% CI) \cell

--- a/tests/testthat/_snaps/tsfvit01apart3/tsfvit01apart3of4.rtf
+++ b/tests/testthat/_snaps/tsfvit01apart3/tsfvit01apart3of4.rtf
@@ -54,7 +54,7 @@
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2838 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4797 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8851 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr n/N (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean (95% CI) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean Change From Baseline (95% CI) \cell

--- a/tests/testthat/_snaps/tsfvit01apart4/tsfvit01apart4of4.rtf
+++ b/tests/testthat/_snaps/tsfvit01apart4/tsfvit01apart4of4.rtf
@@ -45,7 +45,7 @@
 \trowd
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2852 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7776 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr   \cell
 \pard\intbl\qc\fs18 \keepn\trhdr   \cell
 \row

--- a/tests/testthat/_snaps/tsfvit01part1/tsfvit01part1of4.rtf
+++ b/tests/testthat/_snaps/tsfvit01part1/tsfvit01part1of4.rtf
@@ -54,7 +54,7 @@
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2806 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4948 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8935 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr n/N (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean (95% CI) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean Change From Baseline (95% CI) \cell

--- a/tests/testthat/_snaps/tsfvit01part2/tsfvit01part2of4.rtf
+++ b/tests/testthat/_snaps/tsfvit01part2/tsfvit01part2of4.rtf
@@ -54,7 +54,7 @@
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2814 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5020 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9127 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr n/N (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean (95% CI) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean Change From Baseline (95% CI) \cell

--- a/tests/testthat/_snaps/tsfvit01part3/tsfvit01part3of4.rtf
+++ b/tests/testthat/_snaps/tsfvit01part3/tsfvit01part3of4.rtf
@@ -54,7 +54,7 @@
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2840 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5006 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9040 
-\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr n/N (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean (95% CI) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Mean Change From Baseline (95% CI) \cell

--- a/tests/testthat/_snaps/tsfvit01part4/tsfvit01part4of4.rtf
+++ b/tests/testthat/_snaps/tsfvit01part4/tsfvit01part4of4.rtf
@@ -45,7 +45,7 @@
 \trowd
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2811 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8121 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Study Visit \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Study Visit \cell
 \pard\intbl\qc\fs18 \keepn\trhdr   \cell
 \pard\intbl\qc\fs18 \keepn\trhdr   \cell
 \row

--- a/tests/testthat/_snaps/tsfvit05/tsfvit05.rtf
+++ b/tests/testthat/_snaps/tsfvit05/tsfvit05.rtf
@@ -30,7 +30,7 @@
 \trqc \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx2804 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx3894 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx6542 
-\clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Parameter \cell
+\clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Parameter \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline High Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline Low Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Placebo \cell
@@ -42,7 +42,7 @@
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2804 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx3894 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6542 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr    Criteria, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li270\fi0 Criteria, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=59 \cell

--- a/tests/testthat/_snaps/tsicm01/tsicm01.rtf
+++ b/tests/testthat/_snaps/tsicm01/tsicm01.rtf
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6719 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8652 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10584 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Standardized Medication Name \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Standardized Medication Name \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsicm02/tsicm02.rtf
+++ b/tests/testthat/_snaps/tsicm02/tsicm02.rtf
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6719 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8652 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10584 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Base Preferred Term \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Base Preferred Term \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsicm03/tsicm03.rtf
+++ b/tests/testthat/_snaps/tsicm03/tsicm03.rtf
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6719 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8652 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10584 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Standardized Medication Name \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Standardized Medication Name \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsicm04/tsicm04.rtf
+++ b/tests/testthat/_snaps/tsicm04/tsicm04.rtf
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6719 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8652 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10584 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Base Preferred Term \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Base Preferred Term \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsicm05/tsicm05.rtf
+++ b/tests/testthat/_snaps/tsicm05/tsicm05.rtf
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6719 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8652 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10584 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Standardized Medication Name \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Standardized Medication Name \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsicm06/tsicm06.rtf
+++ b/tests/testthat/_snaps/tsicm06/tsicm06.rtf
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6719 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8652 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10584 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Base Preferred Term \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Base Preferred Term \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsicm07/tsicm07.rtf
+++ b/tests/testthat/_snaps/tsicm07/tsicm07.rtf
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6767 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8954 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10723 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Standardized Medication Name \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Standardized Medication Name \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsicm08/tsicm08.rtf
+++ b/tests/testthat/_snaps/tsicm08/tsicm08.rtf
@@ -56,7 +56,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6767 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8954 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10723 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   Base Preferred Term \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Base Preferred Term \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsidem02/tsidem02.rtf
+++ b/tests/testthat/_snaps/tsidem02/tsidem02.rtf
@@ -35,7 +35,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx4392 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx5946 
 \clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx7500 
-\clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Country/Territory \cell
+\clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Country/Territory \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline High Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline Low Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Placebo \cell
@@ -49,7 +49,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4392 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx5946 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7500 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr     Site, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li360\fi0 Site, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=64 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=62 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=59 \cell

--- a/tests/testthat/_snaps/tsids01/tsids01.rtf
+++ b/tests/testthat/_snaps/tsids01/tsids01.rtf
@@ -20,7 +20,7 @@
 {
 \trowd
 \trqc \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx2785 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=306 \cell
 \row
 }

--- a/tests/testthat/_snaps/tsids02/tsids02.rtf
+++ b/tests/testthat/_snaps/tsids02/tsids02.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6880 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8350 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10526 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=84 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=84 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=86 \cell

--- a/tests/testthat/_snaps/tsids02a/tsids02a.rtf
+++ b/tests/testthat/_snaps/tsids02a/tsids02a.rtf
@@ -63,7 +63,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7050 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx8447 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx10574 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx12701 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=84 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=84 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=86 \cell

--- a/tests/testthat/_snaps/tsiex06/tsiex06.rtf
+++ b/tests/testthat/_snaps/tsiex06/tsiex06.rtf
@@ -49,7 +49,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4444 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6026 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7608 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li90\fi0  \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsiex08/tsiex08.rtf
+++ b/tests/testthat/_snaps/tsiex08/tsiex08.rtf
@@ -49,7 +49,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4444 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6026 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7608 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Dose Modification, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Dose Modification, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsiex09/tsiex09.rtf
+++ b/tests/testthat/_snaps/tsiex09/tsiex09.rtf
@@ -49,7 +49,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4444 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6026 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7608 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Lot, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Lot, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsiex11/tsiex11.rtf
+++ b/tests/testthat/_snaps/tsiex11/tsiex11.rtf
@@ -35,7 +35,7 @@
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx4444 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx6026 
 \clbrdrt\brdrs\brdrw18\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx7608 
-\clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Time Relative to Infusion \cell
+\clbrdrt\clbrdrl\clbrdrb\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Time Relative to Infusion \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline High Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Xanomeline Low Dose \cell
 \pard\intbl\qc\fs18 \keepn\trhdr Combined \cell
@@ -49,7 +49,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4444 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6026 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7608 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr     Modification, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li360\fi0 Modification, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=53 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=73 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=126 \cell

--- a/tests/testthat/_snaps/tsimh01/tsimh01.rtf
+++ b/tests/testthat/_snaps/tsimh01/tsimh01.rtf
@@ -49,7 +49,7 @@
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx4456 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx6034 
 \clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx7611 
-\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr   Preferred Term, n (%) \cell
+\clbrdrt\clbrdrl\clbrdrb\brdrs\brdrw18\clbrdrr\clvertalb\cellx9189 \pard\intbl\ql\fs18 \keepn\trhdr \intbl\li180\fi0 Preferred Term, n (%) \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=84 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=84 \cell
 \pard\intbl\qc\fs18 \keepn\trhdr N=86 \cell


### PR DESCRIPTION
with the recent CRAN release of tidytlg v0.12.0, the rtfs snapshots have changed because there is some logic now implemented that each leading whitespace in the first column of the header is translated to left-indentation of 90 twips (approx 0.06 inches), see relevant PR: https://github.com/pharmaverse/tidytlg/pull/62