### PR TITLE
Skip test if missing suggested packages

### DIFF
--- a/tests/testthat/test-lsfae01.R
+++ b/tests/testthat/test-lsfae01.R
@@ -1,9 +1,5 @@
 test_that("lsfae01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsfae01.R"), "lsfae01.rtf")
 })

--- a/tests/testthat/test-lsfae01.R
+++ b/tests/testthat/test-lsfae01.R
@@ -1,3 +1,9 @@
 test_that("lsfae01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsfae01.R"), "lsfae01.rtf")
 })

--- a/tests/testthat/test-lsfae02.R
+++ b/tests/testthat/test-lsfae02.R
@@ -1,9 +1,5 @@
 test_that("lsfae02", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsfae02.R"), "lsfae02.rtf")
 })

--- a/tests/testthat/test-lsfae02.R
+++ b/tests/testthat/test-lsfae02.R
@@ -1,3 +1,9 @@
 test_that("lsfae02", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsfae02.R"), "lsfae02.rtf")
 })

--- a/tests/testthat/test-lsfae03.R
+++ b/tests/testthat/test-lsfae03.R
@@ -1,9 +1,5 @@
 test_that("lsfae03", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsfae03.R"), "lsfae03.rtf")
 })

--- a/tests/testthat/test-lsfae03.R
+++ b/tests/testthat/test-lsfae03.R
@@ -1,3 +1,9 @@
 test_that("lsfae03", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsfae03.R"), "lsfae03.rtf")
 })

--- a/tests/testthat/test-lsfae04.R
+++ b/tests/testthat/test-lsfae04.R
@@ -1,3 +1,9 @@
 test_that("lsfae04", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsfae04.R"), "lsfae04.rtf")
 })

--- a/tests/testthat/test-lsfae04.R
+++ b/tests/testthat/test-lsfae04.R
@@ -1,9 +1,5 @@
 test_that("lsfae04", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsfae04.R"), "lsfae04.rtf")
 })

--- a/tests/testthat/test-lsfae05.R
+++ b/tests/testthat/test-lsfae05.R
@@ -1,3 +1,9 @@
 test_that("lsfae05", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsfae05.R"), "lsfae05.rtf")
 })

--- a/tests/testthat/test-lsfae05.R
+++ b/tests/testthat/test-lsfae05.R
@@ -1,9 +1,5 @@
 test_that("lsfae05", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsfae05.R"), "lsfae05.rtf")
 })

--- a/tests/testthat/test-lsfae06a.R
+++ b/tests/testthat/test-lsfae06a.R
@@ -1,3 +1,9 @@
 test_that("lsfae06a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsfae06a.R"), "lsfae06a.rtf")
 })

--- a/tests/testthat/test-lsfae06a.R
+++ b/tests/testthat/test-lsfae06a.R
@@ -1,9 +1,5 @@
 test_that("lsfae06a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsfae06a.R"), "lsfae06a.rtf")
 })

--- a/tests/testthat/test-lsfae06b.R
+++ b/tests/testthat/test-lsfae06b.R
@@ -1,9 +1,5 @@
 test_that("lsfae06b", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsfae06b.R"), "lsfae06b.rtf")
 })

--- a/tests/testthat/test-lsfae06b.R
+++ b/tests/testthat/test-lsfae06b.R
@@ -1,3 +1,9 @@
 test_that("lsfae06b", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsfae06b.R"), "lsfae06b.rtf")
 })

--- a/tests/testthat/test-lsfdth01.R
+++ b/tests/testthat/test-lsfdth01.R
@@ -1,9 +1,5 @@
 test_that("lsfdth01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsfdth01.R"), "lsfdth01.rtf")
 })

--- a/tests/testthat/test-lsfdth01.R
+++ b/tests/testthat/test-lsfdth01.R
@@ -1,3 +1,9 @@
 test_that("lsfdth01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsfdth01.R"), "lsfdth01.rtf")
 })

--- a/tests/testthat/test-lsfecg01.R
+++ b/tests/testthat/test-lsfecg01.R
@@ -1,3 +1,9 @@
 test_that("lsfecg01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsfecg01.R"), "lsfecg01.rtf")
 })

--- a/tests/testthat/test-lsfecg01.R
+++ b/tests/testthat/test-lsfecg01.R
@@ -1,9 +1,5 @@
 test_that("lsfecg01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsfecg01.R"), "lsfecg01.rtf")
 })

--- a/tests/testthat/test-lsfecg02part1.R
+++ b/tests/testthat/test-lsfecg02part1.R
@@ -1,3 +1,9 @@
 test_that("lsfecg02part1of3", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsfecg02.R", part_num = 1, total_parts = 3), "lsfecg02part1of3.rtf")
 })

--- a/tests/testthat/test-lsfecg02part1.R
+++ b/tests/testthat/test-lsfecg02part1.R
@@ -1,9 +1,5 @@
 test_that("lsfecg02part1of3", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsfecg02.R", part_num = 1, total_parts = 3), "lsfecg02part1of3.rtf")
 })

--- a/tests/testthat/test-lsfecg02part2.R
+++ b/tests/testthat/test-lsfecg02part2.R
@@ -1,3 +1,9 @@
 test_that("lsfecg02part2of3", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsfecg02.R", part_num = 2, total_parts = 3), "lsfecg02part2of3.rtf")
 })

--- a/tests/testthat/test-lsfecg02part2.R
+++ b/tests/testthat/test-lsfecg02part2.R
@@ -1,9 +1,5 @@
 test_that("lsfecg02part2of3", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsfecg02.R", part_num = 2, total_parts = 3), "lsfecg02part2of3.rtf")
 })

--- a/tests/testthat/test-lsfecg02part3.R
+++ b/tests/testthat/test-lsfecg02part3.R
@@ -1,9 +1,5 @@
 test_that("lsfecg02part3of3", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsfecg02.R", part_num = 3, total_parts = 3), "lsfecg02part3of3.rtf")
 })

--- a/tests/testthat/test-lsfecg02part3.R
+++ b/tests/testthat/test-lsfecg02part3.R
@@ -1,3 +1,9 @@
 test_that("lsfecg02part3of3", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsfecg02.R", part_num = 3, total_parts = 3), "lsfecg02part3of3.rtf")
 })

--- a/tests/testthat/test-lsflab01.R
+++ b/tests/testthat/test-lsflab01.R
@@ -1,3 +1,9 @@
 test_that("lsflab01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsflab01.R"), "lsflab01.rtf")
 })

--- a/tests/testthat/test-lsflab01.R
+++ b/tests/testthat/test-lsflab01.R
@@ -1,9 +1,5 @@
 test_that("lsflab01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsflab01.R"), "lsflab01.rtf")
 })

--- a/tests/testthat/test-lsfvit01.R
+++ b/tests/testthat/test-lsfvit01.R
@@ -1,9 +1,5 @@
 test_that("lsfvit01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsfvit01.R"), "lsfvit01.rtf")
 })

--- a/tests/testthat/test-lsfvit01.R
+++ b/tests/testthat/test-lsfvit01.R
@@ -1,3 +1,9 @@
 test_that("lsfvit01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsfvit01.R"), "lsfvit01.rtf")
 })

--- a/tests/testthat/test-lsfvit02.R
+++ b/tests/testthat/test-lsfvit02.R
@@ -1,3 +1,9 @@
 test_that("lsfvit02", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsfvit02.R"), "lsfvit02.rtf")
 })

--- a/tests/testthat/test-lsfvit02.R
+++ b/tests/testthat/test-lsfvit02.R
@@ -1,9 +1,5 @@
 test_that("lsfvit02", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsfvit02.R"), "lsfvit02.rtf")
 })

--- a/tests/testthat/test-lsicm01.R
+++ b/tests/testthat/test-lsicm01.R
@@ -1,3 +1,9 @@
 test_that("lsicm01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsicm01.R"), "lsicm01.rtf")
 })

--- a/tests/testthat/test-lsicm01.R
+++ b/tests/testthat/test-lsicm01.R
@@ -1,9 +1,5 @@
 test_that("lsicm01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsicm01.R"), "lsicm01.rtf")
 })

--- a/tests/testthat/test-lsidem01.R
+++ b/tests/testthat/test-lsidem01.R
@@ -1,9 +1,5 @@
 test_that("lsidem01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsidem01.R"), "lsidem01.rtf")
 })

--- a/tests/testthat/test-lsidem01.R
+++ b/tests/testthat/test-lsidem01.R
@@ -1,3 +1,9 @@
 test_that("lsidem01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsidem01.R"), "lsidem01.rtf")
 })

--- a/tests/testthat/test-lsidem02.R
+++ b/tests/testthat/test-lsidem02.R
@@ -1,9 +1,5 @@
 test_that("lsidem02", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsidem02.R"), "lsidem02.rtf")
 })

--- a/tests/testthat/test-lsidem02.R
+++ b/tests/testthat/test-lsidem02.R
@@ -1,3 +1,9 @@
 test_that("lsidem02", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsidem02.R"), "lsidem02.rtf")
 })

--- a/tests/testthat/test-lsids01.R
+++ b/tests/testthat/test-lsids01.R
@@ -1,3 +1,9 @@
 test_that("lsids01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsids01.R"), "lsids01.rtf")
 })

--- a/tests/testthat/test-lsids01.R
+++ b/tests/testthat/test-lsids01.R
@@ -1,9 +1,5 @@
 test_that("lsids01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsids01.R"), "lsids01.rtf")
 })

--- a/tests/testthat/test-lsids02.R
+++ b/tests/testthat/test-lsids02.R
@@ -1,3 +1,9 @@
 test_that("lsids02", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsids02.R"), "lsids02.rtf")
 })

--- a/tests/testthat/test-lsids02.R
+++ b/tests/testthat/test-lsids02.R
@@ -1,9 +1,5 @@
 test_that("lsids02", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsids02.R"), "lsids02.rtf")
 })

--- a/tests/testthat/test-lsids03.R
+++ b/tests/testthat/test-lsids03.R
@@ -1,9 +1,5 @@
 test_that("lsids03", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsids03.R"), "lsids03.rtf")
 })

--- a/tests/testthat/test-lsids03.R
+++ b/tests/testthat/test-lsids03.R
@@ -1,3 +1,9 @@
 test_that("lsids03", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsids03.R"), "lsids03.rtf")
 })

--- a/tests/testthat/test-lsids04.R
+++ b/tests/testthat/test-lsids04.R
@@ -1,3 +1,9 @@
 test_that("lsids04", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsids04.R"), "lsids04.rtf")
 })

--- a/tests/testthat/test-lsids04.R
+++ b/tests/testthat/test-lsids04.R
@@ -1,9 +1,5 @@
 test_that("lsids04", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsids04.R"), "lsids04.rtf")
 })

--- a/tests/testthat/test-lsids05.R
+++ b/tests/testthat/test-lsids05.R
@@ -1,9 +1,5 @@
 test_that("lsids05", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsids05.R"), "lsids05.rtf")
 })

--- a/tests/testthat/test-lsids05.R
+++ b/tests/testthat/test-lsids05.R
@@ -1,3 +1,9 @@
 test_that("lsids05", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsids05.R"), "lsids05.rtf")
 })

--- a/tests/testthat/test-lsiex01.R
+++ b/tests/testthat/test-lsiex01.R
@@ -1,9 +1,5 @@
 test_that("lsiex01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsiex01.R"), "lsiex01.rtf")
 })

--- a/tests/testthat/test-lsiex01.R
+++ b/tests/testthat/test-lsiex01.R
@@ -1,3 +1,9 @@
 test_that("lsiex01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsiex01.R"), "lsiex01.rtf")
 })

--- a/tests/testthat/test-lsiex02.R
+++ b/tests/testthat/test-lsiex02.R
@@ -1,9 +1,5 @@
 test_that("lsiex02", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsiex02.R"), "lsiex02.rtf")
 })

--- a/tests/testthat/test-lsiex02.R
+++ b/tests/testthat/test-lsiex02.R
@@ -1,3 +1,9 @@
 test_that("lsiex02", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsiex02.R"), "lsiex02.rtf")
 })

--- a/tests/testthat/test-lsiex03.R
+++ b/tests/testthat/test-lsiex03.R
@@ -1,9 +1,5 @@
 test_that("lsiex03", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsiex03.R"), "lsiex03.rtf")
 })

--- a/tests/testthat/test-lsiex03.R
+++ b/tests/testthat/test-lsiex03.R
@@ -1,3 +1,9 @@
 test_that("lsiex03", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsiex03.R"), "lsiex03.rtf")
 })

--- a/tests/testthat/test-lsimh01.R
+++ b/tests/testthat/test-lsimh01.R
@@ -1,9 +1,5 @@
 test_that("lsimh01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("lsimh01.R"), "lsimh01.rtf")
 })

--- a/tests/testthat/test-lsimh01.R
+++ b/tests/testthat/test-lsimh01.R
@@ -1,3 +1,9 @@
 test_that("lsimh01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("lsimh01.R"), "lsimh01.rtf")
 })

--- a/tests/testthat/test-tpk01a.R
+++ b/tests/testthat/test-tpk01a.R
@@ -1,3 +1,9 @@
 test_that("tpk01a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tpk01a.R"), "tpk01a.rtf")
 })

--- a/tests/testthat/test-tpk01a.R
+++ b/tests/testthat/test-tpk01a.R
@@ -1,9 +1,5 @@
 test_that("tpk01a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tpk01a.R"), "tpk01a.rtf")
 })

--- a/tests/testthat/test-tpk01bpart1.R
+++ b/tests/testthat/test-tpk01bpart1.R
@@ -1,9 +1,5 @@
 test_that("tpk01bpart1of2", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tpk01b.R", part_num = 1, total_parts = 2), "tpk01bpart1of2.rtf")
 })

--- a/tests/testthat/test-tpk01bpart1.R
+++ b/tests/testthat/test-tpk01bpart1.R
@@ -1,3 +1,9 @@
 test_that("tpk01bpart1of2", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tpk01b.R", part_num = 1, total_parts = 2), "tpk01bpart1of2.rtf")
 })

--- a/tests/testthat/test-tpk01bpart2.R
+++ b/tests/testthat/test-tpk01bpart2.R
@@ -1,9 +1,5 @@
 test_that("tpk01bpart2of2", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tpk01b.R", part_num = 2, total_parts = 2), "tpk01bpart2of2.rtf")
 })

--- a/tests/testthat/test-tpk01bpart2.R
+++ b/tests/testthat/test-tpk01bpart2.R
@@ -1,3 +1,9 @@
 test_that("tpk01bpart2of2", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tpk01b.R", part_num = 2, total_parts = 2), "tpk01bpart2of2.rtf")
 })

--- a/tests/testthat/test-tpk02part1.R
+++ b/tests/testthat/test-tpk02part1.R
@@ -1,9 +1,5 @@
 test_that("tpk02part1of2", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tpk02.R", part_num = 1, total_parts = 2), "tpk02part1of2.rtf")
 })

--- a/tests/testthat/test-tpk02part1.R
+++ b/tests/testthat/test-tpk02part1.R
@@ -1,3 +1,9 @@
 test_that("tpk02part1of2", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tpk02.R", part_num = 1, total_parts = 2), "tpk02part1of2.rtf")
 })

--- a/tests/testthat/test-tpk02part2.R
+++ b/tests/testthat/test-tpk02part2.R
@@ -1,3 +1,9 @@
 test_that("tpk02part2of2", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tpk02.R", part_num = 2, total_parts = 2), "tpk02part2of2.rtf")
 })

--- a/tests/testthat/test-tpk02part2.R
+++ b/tests/testthat/test-tpk02part2.R
@@ -1,9 +1,5 @@
 test_that("tpk02part2of2", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tpk02.R", part_num = 2, total_parts = 2), "tpk02part2of2.rtf")
 })

--- a/tests/testthat/test-tpk03.R
+++ b/tests/testthat/test-tpk03.R
@@ -1,9 +1,5 @@
 test_that("tpk03", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tpk03.R"), "tpk03.rtf")
 })

--- a/tests/testthat/test-tpk03.R
+++ b/tests/testthat/test-tpk03.R
@@ -1,3 +1,9 @@
 test_that("tpk03", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tpk03.R"), "tpk03.rtf")
 })

--- a/tests/testthat/test-tsfae01a.R
+++ b/tests/testthat/test-tsfae01a.R
@@ -1,3 +1,9 @@
 test_that("tsfae01a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae01a.R"), "tsfae01a.rtf")
 })

--- a/tests/testthat/test-tsfae01a.R
+++ b/tests/testthat/test-tsfae01a.R
@@ -1,9 +1,5 @@
 test_that("tsfae01a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae01a.R"), "tsfae01a.rtf")
 })

--- a/tests/testthat/test-tsfae01b.R
+++ b/tests/testthat/test-tsfae01b.R
@@ -1,9 +1,5 @@
 test_that("tsfae01b", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae01b.R"), "tsfae01b.rtf")
 })

--- a/tests/testthat/test-tsfae01b.R
+++ b/tests/testthat/test-tsfae01b.R
@@ -1,3 +1,9 @@
 test_that("tsfae01b", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae01b.R"), "tsfae01b.rtf")
 })

--- a/tests/testthat/test-tsfae02.R
+++ b/tests/testthat/test-tsfae02.R
@@ -1,3 +1,9 @@
 test_that("tsfae02", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae02.R"), "tsfae02.rtf")
 })

--- a/tests/testthat/test-tsfae02.R
+++ b/tests/testthat/test-tsfae02.R
@@ -1,9 +1,5 @@
 test_that("tsfae02", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae02.R"), "tsfae02.rtf")
 })

--- a/tests/testthat/test-tsfae02a.R
+++ b/tests/testthat/test-tsfae02a.R
@@ -1,3 +1,9 @@
 test_that("tsfae02a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae02a.R"), "tsfae02a.rtf")
 })

--- a/tests/testthat/test-tsfae02a.R
+++ b/tests/testthat/test-tsfae02a.R
@@ -1,9 +1,5 @@
 test_that("tsfae02a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae02a.R"), "tsfae02a.rtf")
 })

--- a/tests/testthat/test-tsfae03.R
+++ b/tests/testthat/test-tsfae03.R
@@ -1,9 +1,5 @@
 test_that("tsfae03", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae03.R"), "tsfae03.rtf")
 })

--- a/tests/testthat/test-tsfae03.R
+++ b/tests/testthat/test-tsfae03.R
@@ -1,3 +1,9 @@
 test_that("tsfae03", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae03.R"), "tsfae03.rtf")
 })

--- a/tests/testthat/test-tsfae03a.R
+++ b/tests/testthat/test-tsfae03a.R
@@ -1,9 +1,5 @@
 test_that("tsfae03a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae03a.R"), "tsfae03a.rtf")
 })

--- a/tests/testthat/test-tsfae03a.R
+++ b/tests/testthat/test-tsfae03a.R
@@ -1,3 +1,9 @@
 test_that("tsfae03a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae03a.R"), "tsfae03a.rtf")
 })

--- a/tests/testthat/test-tsfae04.R
+++ b/tests/testthat/test-tsfae04.R
@@ -1,3 +1,9 @@
 test_that("tsfae04", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae04.R"), "tsfae04.rtf")
 })

--- a/tests/testthat/test-tsfae04.R
+++ b/tests/testthat/test-tsfae04.R
@@ -1,9 +1,5 @@
 test_that("tsfae04", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae04.R"), "tsfae04.rtf")
 })

--- a/tests/testthat/test-tsfae04a.R
+++ b/tests/testthat/test-tsfae04a.R
@@ -1,3 +1,9 @@
 test_that("tsfae04a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae04a.R"), "tsfae04a.rtf")
 })

--- a/tests/testthat/test-tsfae04a.R
+++ b/tests/testthat/test-tsfae04a.R
@@ -1,9 +1,5 @@
 test_that("tsfae04a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae04a.R"), "tsfae04a.rtf")
 })

--- a/tests/testthat/test-tsfae05.R
+++ b/tests/testthat/test-tsfae05.R
@@ -1,3 +1,9 @@
 test_that("tsfae05", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae05.R"), "tsfae05.rtf")
 })

--- a/tests/testthat/test-tsfae05.R
+++ b/tests/testthat/test-tsfae05.R
@@ -1,9 +1,5 @@
 test_that("tsfae05", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae05.R"), "tsfae05.rtf")
 })

--- a/tests/testthat/test-tsfae05a.R
+++ b/tests/testthat/test-tsfae05a.R
@@ -1,3 +1,9 @@
 test_that("tsfae05a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae05a.R"), "tsfae05a.rtf")
 })

--- a/tests/testthat/test-tsfae05a.R
+++ b/tests/testthat/test-tsfae05a.R
@@ -1,9 +1,5 @@
 test_that("tsfae05a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae05a.R"), "tsfae05a.rtf")
 })

--- a/tests/testthat/test-tsfae06a.R
+++ b/tests/testthat/test-tsfae06a.R
@@ -1,3 +1,9 @@
 test_that("tsfae06a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae06a.R"), "tsfae06a.rtf")
 })

--- a/tests/testthat/test-tsfae06a.R
+++ b/tests/testthat/test-tsfae06a.R
@@ -1,9 +1,5 @@
 test_that("tsfae06a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae06a.R"), "tsfae06a.rtf")
 })

--- a/tests/testthat/test-tsfae06b.R
+++ b/tests/testthat/test-tsfae06b.R
@@ -1,9 +1,5 @@
 test_that("tsfae06b", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae06b.R"), "tsfae06b.rtf")
 })

--- a/tests/testthat/test-tsfae06b.R
+++ b/tests/testthat/test-tsfae06b.R
@@ -1,3 +1,9 @@
 test_that("tsfae06b", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae06b.R"), "tsfae06b.rtf")
 })

--- a/tests/testthat/test-tsfae07a.R
+++ b/tests/testthat/test-tsfae07a.R
@@ -1,9 +1,5 @@
 test_that("tsfae07a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae07a.R"), "tsfae07a.rtf")
 })

--- a/tests/testthat/test-tsfae07a.R
+++ b/tests/testthat/test-tsfae07a.R
@@ -1,3 +1,9 @@
 test_that("tsfae07a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae07a.R"), "tsfae07a.rtf")
 })

--- a/tests/testthat/test-tsfae07b.R
+++ b/tests/testthat/test-tsfae07b.R
@@ -1,9 +1,5 @@
 test_that("tsfae07b", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae07b.R"), "tsfae07b.rtf")
 })

--- a/tests/testthat/test-tsfae07b.R
+++ b/tests/testthat/test-tsfae07b.R
@@ -1,3 +1,9 @@
 test_that("tsfae07b", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae07b.R"), "tsfae07b.rtf")
 })

--- a/tests/testthat/test-tsfae08.R
+++ b/tests/testthat/test-tsfae08.R
@@ -1,9 +1,5 @@
 test_that("tsfae08", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae08.R"), "tsfae08.rtf")
 })

--- a/tests/testthat/test-tsfae08.R
+++ b/tests/testthat/test-tsfae08.R
@@ -1,3 +1,9 @@
 test_that("tsfae08", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae08.R"), "tsfae08.rtf")
 })

--- a/tests/testthat/test-tsfae09.R
+++ b/tests/testthat/test-tsfae09.R
@@ -1,3 +1,9 @@
 test_that("tsfae09", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae09.R"), "tsfae09.rtf")
 })

--- a/tests/testthat/test-tsfae09.R
+++ b/tests/testthat/test-tsfae09.R
@@ -1,9 +1,5 @@
 test_that("tsfae09", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae09.R"), "tsfae09.rtf")
 })

--- a/tests/testthat/test-tsfae10.R
+++ b/tests/testthat/test-tsfae10.R
@@ -1,3 +1,9 @@
 test_that("tsfae10", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae10.R"), "tsfae10.rtf")
 })

--- a/tests/testthat/test-tsfae10.R
+++ b/tests/testthat/test-tsfae10.R
@@ -1,9 +1,5 @@
 test_that("tsfae10", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae10.R"), "tsfae10.rtf")
 })

--- a/tests/testthat/test-tsfae11.R
+++ b/tests/testthat/test-tsfae11.R
@@ -1,3 +1,9 @@
 test_that("tsfae11", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae11.R"), "tsfae11.rtf")
 })

--- a/tests/testthat/test-tsfae11.R
+++ b/tests/testthat/test-tsfae11.R
@@ -1,9 +1,5 @@
 test_that("tsfae11", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae11.R"), "tsfae11.rtf")
 })

--- a/tests/testthat/test-tsfae12.R
+++ b/tests/testthat/test-tsfae12.R
@@ -1,3 +1,9 @@
 test_that("tsfae12", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae12.R"), "tsfae12.rtf")
 })

--- a/tests/testthat/test-tsfae12.R
+++ b/tests/testthat/test-tsfae12.R
@@ -1,9 +1,5 @@
 test_that("tsfae12", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae12.R"), "tsfae12.rtf")
 })

--- a/tests/testthat/test-tsfae13.R
+++ b/tests/testthat/test-tsfae13.R
@@ -1,3 +1,9 @@
 test_that("tsfae13", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae13.R"), "tsfae13.rtf")
 })

--- a/tests/testthat/test-tsfae13.R
+++ b/tests/testthat/test-tsfae13.R
@@ -1,9 +1,5 @@
 test_that("tsfae13", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae13.R"), "tsfae13.rtf")
 })

--- a/tests/testthat/test-tsfae14.R
+++ b/tests/testthat/test-tsfae14.R
@@ -1,3 +1,9 @@
 test_that("tsfae14", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae14.R"), "tsfae14.rtf")
 })

--- a/tests/testthat/test-tsfae14.R
+++ b/tests/testthat/test-tsfae14.R
@@ -1,9 +1,5 @@
 test_that("tsfae14", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae14.R"), "tsfae14.rtf")
 })

--- a/tests/testthat/test-tsfae15.R
+++ b/tests/testthat/test-tsfae15.R
@@ -1,3 +1,9 @@
 test_that("tsfae15", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae15.R"), "tsfae15.rtf")
 })

--- a/tests/testthat/test-tsfae15.R
+++ b/tests/testthat/test-tsfae15.R
@@ -1,9 +1,5 @@
 test_that("tsfae15", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae15.R"), "tsfae15.rtf")
 })

--- a/tests/testthat/test-tsfae16part1.R
+++ b/tests/testthat/test-tsfae16part1.R
@@ -1,3 +1,9 @@
 test_that("tsfae16part1of2", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae16.R", part_num = 1, total_parts = 2), "tsfae16part1of2.rtf")
 })

--- a/tests/testthat/test-tsfae16part1.R
+++ b/tests/testthat/test-tsfae16part1.R
@@ -1,9 +1,5 @@
 test_that("tsfae16part1of2", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae16.R", part_num = 1, total_parts = 2), "tsfae16part1of2.rtf")
 })

--- a/tests/testthat/test-tsfae16part2.R
+++ b/tests/testthat/test-tsfae16part2.R
@@ -1,3 +1,9 @@
 test_that("tsfae16part2of2", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae16.R", part_num = 2, total_parts = 2), "tsfae16part2of2.rtf")
 })

--- a/tests/testthat/test-tsfae16part2.R
+++ b/tests/testthat/test-tsfae16part2.R
@@ -1,9 +1,5 @@
 test_that("tsfae16part2of2", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae16.R", part_num = 2, total_parts = 2), "tsfae16part2of2.rtf")
 })

--- a/tests/testthat/test-tsfae17a.R
+++ b/tests/testthat/test-tsfae17a.R
@@ -1,9 +1,5 @@
 test_that("tsfae17a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae17a.R"), "tsfae17a.rtf")
 })

--- a/tests/testthat/test-tsfae17a.R
+++ b/tests/testthat/test-tsfae17a.R
@@ -1,3 +1,9 @@
 test_that("tsfae17a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae17a.R"), "tsfae17a.rtf")
 })

--- a/tests/testthat/test-tsfae17b.R
+++ b/tests/testthat/test-tsfae17b.R
@@ -1,3 +1,9 @@
 test_that("tsfae17b", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae17b.R"), "tsfae17b.rtf")
 })

--- a/tests/testthat/test-tsfae17b.R
+++ b/tests/testthat/test-tsfae17b.R
@@ -1,9 +1,5 @@
 test_that("tsfae17b", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae17b.R"), "tsfae17b.rtf")
 })

--- a/tests/testthat/test-tsfae17c.R
+++ b/tests/testthat/test-tsfae17c.R
@@ -1,9 +1,5 @@
 test_that("tsfae17c", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae17c.R"), "tsfae17c.rtf")
 })

--- a/tests/testthat/test-tsfae17c.R
+++ b/tests/testthat/test-tsfae17c.R
@@ -1,3 +1,9 @@
 test_that("tsfae17c", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae17c.R"), "tsfae17c.rtf")
 })

--- a/tests/testthat/test-tsfae17d.R
+++ b/tests/testthat/test-tsfae17d.R
@@ -1,3 +1,9 @@
 test_that("tsfae17d", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae17d.R"), "tsfae17d.rtf")
 })

--- a/tests/testthat/test-tsfae17d.R
+++ b/tests/testthat/test-tsfae17d.R
@@ -1,9 +1,5 @@
 test_that("tsfae17d", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae17d.R"), "tsfae17d.rtf")
 })

--- a/tests/testthat/test-tsfae19a.R
+++ b/tests/testthat/test-tsfae19a.R
@@ -1,5 +1,11 @@
 Sys.setenv(JUNCO_DISABLE_VALIDATION = TRUE)
 test_that("tsfae19a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae19a.R"), "tsfae19a.rtf")
 })
 Sys.setenv(JUNCO_DISABLE_VALIDATION = FALSE)

--- a/tests/testthat/test-tsfae19a.R
+++ b/tests/testthat/test-tsfae19a.R
@@ -1,11 +1,7 @@
 Sys.setenv(JUNCO_DISABLE_VALIDATION = TRUE)
 test_that("tsfae19a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae19a.R"), "tsfae19a.rtf")
 })
 Sys.setenv(JUNCO_DISABLE_VALIDATION = FALSE)

--- a/tests/testthat/test-tsfae19b.R
+++ b/tests/testthat/test-tsfae19b.R
@@ -1,5 +1,11 @@
 Sys.setenv(JUNCO_DISABLE_VALIDATION = TRUE)
 test_that("tsfae19b", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae19b.R"), "tsfae19b.rtf")
 })
 Sys.setenv(JUNCO_DISABLE_VALIDATION = FALSE)

--- a/tests/testthat/test-tsfae19b.R
+++ b/tests/testthat/test-tsfae19b.R
@@ -1,11 +1,7 @@
 Sys.setenv(JUNCO_DISABLE_VALIDATION = TRUE)
 test_that("tsfae19b", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae19b.R"), "tsfae19b.rtf")
 })
 Sys.setenv(JUNCO_DISABLE_VALIDATION = FALSE)

--- a/tests/testthat/test-tsfae19c.R
+++ b/tests/testthat/test-tsfae19c.R
@@ -1,5 +1,11 @@
 Sys.setenv(JUNCO_DISABLE_VALIDATION = TRUE)
 test_that("tsfae19c", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae19c.R"), "tsfae19c.rtf")
 })
 Sys.setenv(JUNCO_DISABLE_VALIDATION = FALSE)

--- a/tests/testthat/test-tsfae19c.R
+++ b/tests/testthat/test-tsfae19c.R
@@ -1,11 +1,7 @@
 Sys.setenv(JUNCO_DISABLE_VALIDATION = TRUE)
 test_that("tsfae19c", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae19c.R"), "tsfae19c.rtf")
 })
 Sys.setenv(JUNCO_DISABLE_VALIDATION = FALSE)

--- a/tests/testthat/test-tsfae19d.R
+++ b/tests/testthat/test-tsfae19d.R
@@ -1,5 +1,11 @@
 Sys.setenv(JUNCO_DISABLE_VALIDATION = TRUE)
 test_that("tsfae19d", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae19d.R"), "tsfae19d.rtf")
 })
 Sys.setenv(JUNCO_DISABLE_VALIDATION = FALSE)

--- a/tests/testthat/test-tsfae19d.R
+++ b/tests/testthat/test-tsfae19d.R
@@ -1,11 +1,7 @@
 Sys.setenv(JUNCO_DISABLE_VALIDATION = TRUE)
 test_that("tsfae19d", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae19d.R"), "tsfae19d.rtf")
 })
 Sys.setenv(JUNCO_DISABLE_VALIDATION = FALSE)

--- a/tests/testthat/test-tsfae20a.R
+++ b/tests/testthat/test-tsfae20a.R
@@ -1,9 +1,5 @@
 test_that("tsfae20a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae20a.R"), "tsfae20a.rtf")
 })

--- a/tests/testthat/test-tsfae20a.R
+++ b/tests/testthat/test-tsfae20a.R
@@ -1,3 +1,9 @@
 test_that("tsfae20a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae20a.R"), "tsfae20a.rtf")
 })

--- a/tests/testthat/test-tsfae20b.R
+++ b/tests/testthat/test-tsfae20b.R
@@ -1,9 +1,5 @@
 test_that("tsfae20b", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae20b.R"), "tsfae20b.rtf")
 })

--- a/tests/testthat/test-tsfae20b.R
+++ b/tests/testthat/test-tsfae20b.R
@@ -1,3 +1,9 @@
 test_that("tsfae20b", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae20b.R"), "tsfae20b.rtf")
 })

--- a/tests/testthat/test-tsfae20c.R
+++ b/tests/testthat/test-tsfae20c.R
@@ -1,9 +1,5 @@
 test_that("tsfae20c", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae20c.R"), "tsfae20c.rtf")
 })

--- a/tests/testthat/test-tsfae20c.R
+++ b/tests/testthat/test-tsfae20c.R
@@ -1,3 +1,9 @@
 test_that("tsfae20c", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae20c.R"), "tsfae20c.rtf")
 })

--- a/tests/testthat/test-tsfae21apart1.R
+++ b/tests/testthat/test-tsfae21apart1.R
@@ -1,3 +1,9 @@
 test_that("tsfae21apart1of4", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae21a.R", part_num = 1, total_parts = 4), "tsfae21apart1of4.rtf")
 })

--- a/tests/testthat/test-tsfae21apart1.R
+++ b/tests/testthat/test-tsfae21apart1.R
@@ -1,9 +1,5 @@
 test_that("tsfae21apart1of4", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae21a.R", part_num = 1, total_parts = 4), "tsfae21apart1of4.rtf")
 })

--- a/tests/testthat/test-tsfae21apart2.R
+++ b/tests/testthat/test-tsfae21apart2.R
@@ -1,9 +1,5 @@
 test_that("tsfae21apart2of4", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae21a.R", part_num = 2, total_parts = 4), "tsfae21apart2of4.rtf")
 })

--- a/tests/testthat/test-tsfae21apart2.R
+++ b/tests/testthat/test-tsfae21apart2.R
@@ -1,3 +1,9 @@
 test_that("tsfae21apart2of4", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae21a.R", part_num = 2, total_parts = 4), "tsfae21apart2of4.rtf")
 })

--- a/tests/testthat/test-tsfae21apart3.R
+++ b/tests/testthat/test-tsfae21apart3.R
@@ -1,3 +1,9 @@
 test_that("tsfae21apart3of4", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae21a.R", part_num = 3, total_parts = 4), "tsfae21apart3of4.rtf")
 })

--- a/tests/testthat/test-tsfae21apart3.R
+++ b/tests/testthat/test-tsfae21apart3.R
@@ -1,9 +1,5 @@
 test_that("tsfae21apart3of4", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae21a.R", part_num = 3, total_parts = 4), "tsfae21apart3of4.rtf")
 })

--- a/tests/testthat/test-tsfae21apart4.R
+++ b/tests/testthat/test-tsfae21apart4.R
@@ -1,9 +1,5 @@
 test_that("tsfae21apart4of4", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae21a.R", part_num = 4, total_parts = 4), "tsfae21apart4of4.rtf")
 })

--- a/tests/testthat/test-tsfae21apart4.R
+++ b/tests/testthat/test-tsfae21apart4.R
@@ -1,3 +1,9 @@
 test_that("tsfae21apart4of4", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae21a.R", part_num = 4, total_parts = 4), "tsfae21apart4of4.rtf")
 })

--- a/tests/testthat/test-tsfae21bpart1.R
+++ b/tests/testthat/test-tsfae21bpart1.R
@@ -1,3 +1,9 @@
 test_that("tsfae21bpart1of4", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae21b.R", part_num = 1, total_parts = 4), "tsfae21bpart1of4.rtf")
 })

--- a/tests/testthat/test-tsfae21bpart1.R
+++ b/tests/testthat/test-tsfae21bpart1.R
@@ -1,9 +1,5 @@
 test_that("tsfae21bpart1of4", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae21b.R", part_num = 1, total_parts = 4), "tsfae21bpart1of4.rtf")
 })

--- a/tests/testthat/test-tsfae21bpart2.R
+++ b/tests/testthat/test-tsfae21bpart2.R
@@ -1,3 +1,9 @@
 test_that("tsfae21bpart2of4", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae21b.R", part_num = 2, total_parts = 4), "tsfae21bpart2of4.rtf")
 })

--- a/tests/testthat/test-tsfae21bpart2.R
+++ b/tests/testthat/test-tsfae21bpart2.R
@@ -1,9 +1,5 @@
 test_that("tsfae21bpart2of4", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae21b.R", part_num = 2, total_parts = 4), "tsfae21bpart2of4.rtf")
 })

--- a/tests/testthat/test-tsfae21bpart3.R
+++ b/tests/testthat/test-tsfae21bpart3.R
@@ -1,3 +1,9 @@
 test_that("tsfae21bpart3of4", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae21b.R", part_num = 3, total_parts = 4), "tsfae21bpart3of4.rtf")
 })

--- a/tests/testthat/test-tsfae21bpart3.R
+++ b/tests/testthat/test-tsfae21bpart3.R
@@ -1,9 +1,5 @@
 test_that("tsfae21bpart3of4", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae21b.R", part_num = 3, total_parts = 4), "tsfae21bpart3of4.rtf")
 })

--- a/tests/testthat/test-tsfae21bpart4.R
+++ b/tests/testthat/test-tsfae21bpart4.R
@@ -1,9 +1,5 @@
 test_that("tsfae21bpart4of4", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae21b.R", part_num = 4, total_parts = 4), "tsfae21bpart4of4.rtf")
 })

--- a/tests/testthat/test-tsfae21bpart4.R
+++ b/tests/testthat/test-tsfae21bpart4.R
@@ -1,3 +1,9 @@
 test_that("tsfae21bpart4of4", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae21b.R", part_num = 4, total_parts = 4), "tsfae21bpart4of4.rtf")
 })

--- a/tests/testthat/test-tsfae21c.R
+++ b/tests/testthat/test-tsfae21c.R
@@ -1,3 +1,9 @@
 test_that("tsfae21c", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae21c.R"), "tsfae21c.rtf")
 })

--- a/tests/testthat/test-tsfae21c.R
+++ b/tests/testthat/test-tsfae21c.R
@@ -1,9 +1,5 @@
 test_that("tsfae21c", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae21c.R"), "tsfae21c.rtf")
 })

--- a/tests/testthat/test-tsfae21d.R
+++ b/tests/testthat/test-tsfae21d.R
@@ -1,9 +1,5 @@
 test_that("tsfae21d", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae21d.R"), "tsfae21d.rtf")
 })

--- a/tests/testthat/test-tsfae21d.R
+++ b/tests/testthat/test-tsfae21d.R
@@ -1,3 +1,9 @@
 test_that("tsfae21d", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae21d.R"), "tsfae21d.rtf")
 })

--- a/tests/testthat/test-tsfae22apart1.R
+++ b/tests/testthat/test-tsfae22apart1.R
@@ -1,9 +1,5 @@
 test_that("tsfae22apart1of4", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae22a.R", part_num = 1, total_parts = 4), "tsfae22apart1of4.rtf")
 })

--- a/tests/testthat/test-tsfae22apart1.R
+++ b/tests/testthat/test-tsfae22apart1.R
@@ -1,3 +1,9 @@
 test_that("tsfae22apart1of4", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae22a.R", part_num = 1, total_parts = 4), "tsfae22apart1of4.rtf")
 })

--- a/tests/testthat/test-tsfae22apart2.R
+++ b/tests/testthat/test-tsfae22apart2.R
@@ -1,3 +1,9 @@
 test_that("tsfae22apart2of4", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae22a.R", part_num = 2, total_parts = 4), "tsfae22apart2of4.rtf")
 })

--- a/tests/testthat/test-tsfae22apart2.R
+++ b/tests/testthat/test-tsfae22apart2.R
@@ -1,9 +1,5 @@
 test_that("tsfae22apart2of4", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae22a.R", part_num = 2, total_parts = 4), "tsfae22apart2of4.rtf")
 })

--- a/tests/testthat/test-tsfae22apart3.R
+++ b/tests/testthat/test-tsfae22apart3.R
@@ -1,3 +1,9 @@
 test_that("tsfae22apart3of4", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae22a.R", part_num = 3, total_parts = 4), "tsfae22apart3of4.rtf")
 })

--- a/tests/testthat/test-tsfae22apart3.R
+++ b/tests/testthat/test-tsfae22apart3.R
@@ -1,9 +1,5 @@
 test_that("tsfae22apart3of4", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae22a.R", part_num = 3, total_parts = 4), "tsfae22apart3of4.rtf")
 })

--- a/tests/testthat/test-tsfae22apart4.R
+++ b/tests/testthat/test-tsfae22apart4.R
@@ -1,9 +1,5 @@
 test_that("tsfae22apart4of4", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae22a.R", part_num = 4, total_parts = 4), "tsfae22apart4of4.rtf")
 })

--- a/tests/testthat/test-tsfae22apart4.R
+++ b/tests/testthat/test-tsfae22apart4.R
@@ -1,3 +1,9 @@
 test_that("tsfae22apart4of4", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae22a.R", part_num = 4, total_parts = 4), "tsfae22apart4of4.rtf")
 })

--- a/tests/testthat/test-tsfae22bpart1.R
+++ b/tests/testthat/test-tsfae22bpart1.R
@@ -1,9 +1,5 @@
 test_that("tsfae22bpart1of2", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae22b.R", part_num = 1, total_parts = 2), "tsfae22bpart1of2.rtf")
 })

--- a/tests/testthat/test-tsfae22bpart1.R
+++ b/tests/testthat/test-tsfae22bpart1.R
@@ -1,3 +1,9 @@
 test_that("tsfae22bpart1of2", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae22b.R", part_num = 1, total_parts = 2), "tsfae22bpart1of2.rtf")
 })

--- a/tests/testthat/test-tsfae22bpart2.R
+++ b/tests/testthat/test-tsfae22bpart2.R
@@ -1,9 +1,5 @@
 test_that("tsfae22bpart2of2", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae22b.R", part_num = 2, total_parts = 2), "tsfae22bpart2of2.rtf")
 })

--- a/tests/testthat/test-tsfae22bpart2.R
+++ b/tests/testthat/test-tsfae22bpart2.R
@@ -1,3 +1,9 @@
 test_that("tsfae22bpart2of2", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae22b.R", part_num = 2, total_parts = 2), "tsfae22bpart2of2.rtf")
 })

--- a/tests/testthat/test-tsfae22cpart1.R
+++ b/tests/testthat/test-tsfae22cpart1.R
@@ -1,3 +1,9 @@
 test_that("tsfae22cpart1of4", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae22c.R", part_num = 1, total_parts = 4), "tsfae22cpart1of4.rtf")
 })

--- a/tests/testthat/test-tsfae22cpart1.R
+++ b/tests/testthat/test-tsfae22cpart1.R
@@ -1,9 +1,5 @@
 test_that("tsfae22cpart1of4", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae22c.R", part_num = 1, total_parts = 4), "tsfae22cpart1of4.rtf")
 })

--- a/tests/testthat/test-tsfae22cpart2.R
+++ b/tests/testthat/test-tsfae22cpart2.R
@@ -1,3 +1,9 @@
 test_that("tsfae22cpart2of4", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae22c.R", part_num = 2, total_parts = 4), "tsfae22cpart2of4.rtf")
 })

--- a/tests/testthat/test-tsfae22cpart2.R
+++ b/tests/testthat/test-tsfae22cpart2.R
@@ -1,9 +1,5 @@
 test_that("tsfae22cpart2of4", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae22c.R", part_num = 2, total_parts = 4), "tsfae22cpart2of4.rtf")
 })

--- a/tests/testthat/test-tsfae22cpart3.R
+++ b/tests/testthat/test-tsfae22cpart3.R
@@ -1,9 +1,5 @@
 test_that("tsfae22cpart3of4", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae22c.R", part_num = 3, total_parts = 4), "tsfae22cpart3of4.rtf")
 })

--- a/tests/testthat/test-tsfae22cpart3.R
+++ b/tests/testthat/test-tsfae22cpart3.R
@@ -1,3 +1,9 @@
 test_that("tsfae22cpart3of4", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae22c.R", part_num = 3, total_parts = 4), "tsfae22cpart3of4.rtf")
 })

--- a/tests/testthat/test-tsfae22cpart4.R
+++ b/tests/testthat/test-tsfae22cpart4.R
@@ -1,3 +1,9 @@
 test_that("tsfae22cpart4of4", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae22c.R", part_num = 4, total_parts = 4), "tsfae22cpart4of4.rtf")
 })

--- a/tests/testthat/test-tsfae22cpart4.R
+++ b/tests/testthat/test-tsfae22cpart4.R
@@ -1,9 +1,5 @@
 test_that("tsfae22cpart4of4", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae22c.R", part_num = 4, total_parts = 4), "tsfae22cpart4of4.rtf")
 })

--- a/tests/testthat/test-tsfae23a.R
+++ b/tests/testthat/test-tsfae23a.R
@@ -1,9 +1,5 @@
 test_that("tsfae23a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae23a.R"), "tsfae23a.rtf")
 })

--- a/tests/testthat/test-tsfae23a.R
+++ b/tests/testthat/test-tsfae23a.R
@@ -1,3 +1,9 @@
 test_that("tsfae23a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae23a.R"), "tsfae23a.rtf")
 })

--- a/tests/testthat/test-tsfae23b.R
+++ b/tests/testthat/test-tsfae23b.R
@@ -1,9 +1,5 @@
 test_that("tsfae23b", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae23b.R"), "tsfae23b.rtf")
 })

--- a/tests/testthat/test-tsfae23b.R
+++ b/tests/testthat/test-tsfae23b.R
@@ -1,3 +1,9 @@
 test_that("tsfae23b", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae23b.R"), "tsfae23b.rtf")
 })

--- a/tests/testthat/test-tsfae23c.R
+++ b/tests/testthat/test-tsfae23c.R
@@ -1,9 +1,5 @@
 test_that("tsfae23c", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae23c.R"), "tsfae23c.rtf")
 })

--- a/tests/testthat/test-tsfae23c.R
+++ b/tests/testthat/test-tsfae23c.R
@@ -1,3 +1,9 @@
 test_that("tsfae23c", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae23c.R"), "tsfae23c.rtf")
 })

--- a/tests/testthat/test-tsfae23d.R
+++ b/tests/testthat/test-tsfae23d.R
@@ -1,3 +1,9 @@
 test_that("tsfae23d", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae23d.R"), "tsfae23d.rtf")
 })

--- a/tests/testthat/test-tsfae23d.R
+++ b/tests/testthat/test-tsfae23d.R
@@ -1,9 +1,5 @@
 test_that("tsfae23d", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae23d.R"), "tsfae23d.rtf")
 })

--- a/tests/testthat/test-tsfae24a.R
+++ b/tests/testthat/test-tsfae24a.R
@@ -1,3 +1,9 @@
 test_that("tsfae24a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae24a.R"), "tsfae24a.rtf")
 })

--- a/tests/testthat/test-tsfae24a.R
+++ b/tests/testthat/test-tsfae24a.R
@@ -1,9 +1,5 @@
 test_that("tsfae24a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae24a.R"), "tsfae24a.rtf")
 })

--- a/tests/testthat/test-tsfae24b.R
+++ b/tests/testthat/test-tsfae24b.R
@@ -1,9 +1,5 @@
 test_that("tsfae24b", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae24b.R"), "tsfae24b.rtf")
 })

--- a/tests/testthat/test-tsfae24b.R
+++ b/tests/testthat/test-tsfae24b.R
@@ -1,3 +1,9 @@
 test_that("tsfae24b", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae24b.R"), "tsfae24b.rtf")
 })

--- a/tests/testthat/test-tsfae24c.R
+++ b/tests/testthat/test-tsfae24c.R
@@ -1,9 +1,5 @@
 test_that("tsfae24c", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae24c.R"), "tsfae24c.rtf")
 })

--- a/tests/testthat/test-tsfae24c.R
+++ b/tests/testthat/test-tsfae24c.R
@@ -1,3 +1,9 @@
 test_that("tsfae24c", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae24c.R"), "tsfae24c.rtf")
 })

--- a/tests/testthat/test-tsfae24d.R
+++ b/tests/testthat/test-tsfae24d.R
@@ -1,3 +1,9 @@
 test_that("tsfae24d", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae24d.R"), "tsfae24d.rtf")
 })

--- a/tests/testthat/test-tsfae24d.R
+++ b/tests/testthat/test-tsfae24d.R
@@ -1,9 +1,5 @@
 test_that("tsfae24d", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae24d.R"), "tsfae24d.rtf")
 })

--- a/tests/testthat/test-tsfae24fpart1.R
+++ b/tests/testthat/test-tsfae24fpart1.R
@@ -1,9 +1,5 @@
 test_that("tsfae24fpart1of3", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae24f.R", part_num = 1, total_parts = 3), "tsfae24fpart1of3.rtf")
 })

--- a/tests/testthat/test-tsfae24fpart1.R
+++ b/tests/testthat/test-tsfae24fpart1.R
@@ -1,3 +1,9 @@
 test_that("tsfae24fpart1of3", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae24f.R", part_num = 1, total_parts = 3), "tsfae24fpart1of3.rtf")
 })

--- a/tests/testthat/test-tsfae24fpart2.R
+++ b/tests/testthat/test-tsfae24fpart2.R
@@ -1,3 +1,9 @@
 test_that("tsfae24fpart2of3", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae24f.R", part_num = 2, total_parts = 3), "tsfae24fpart2of3.rtf")
 })

--- a/tests/testthat/test-tsfae24fpart2.R
+++ b/tests/testthat/test-tsfae24fpart2.R
@@ -1,9 +1,5 @@
 test_that("tsfae24fpart2of3", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae24f.R", part_num = 2, total_parts = 3), "tsfae24fpart2of3.rtf")
 })

--- a/tests/testthat/test-tsfae24fpart3.R
+++ b/tests/testthat/test-tsfae24fpart3.R
@@ -1,9 +1,5 @@
 test_that("tsfae24fpart3of3", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfae24f.R", part_num = 3, total_parts = 3), "tsfae24fpart3of3.rtf")
 })

--- a/tests/testthat/test-tsfae24fpart3.R
+++ b/tests/testthat/test-tsfae24fpart3.R
@@ -1,3 +1,9 @@
 test_that("tsfae24fpart3of3", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfae24f.R", part_num = 3, total_parts = 3), "tsfae24fpart3of3.rtf")
 })

--- a/tests/testthat/test-tsfdth01.R
+++ b/tests/testthat/test-tsfdth01.R
@@ -1,9 +1,5 @@
 test_that("tsfdth01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfdth01.R"), "tsfdth01.rtf")
 })

--- a/tests/testthat/test-tsfdth01.R
+++ b/tests/testthat/test-tsfdth01.R
@@ -1,3 +1,9 @@
 test_that("tsfdth01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfdth01.R"), "tsfdth01.rtf")
 })

--- a/tests/testthat/test-tsfecg01apart1.R
+++ b/tests/testthat/test-tsfecg01apart1.R
@@ -1,3 +1,9 @@
 test_that("tsfecg01a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfecg01a.R", part_num = 1, total_parts = 3), "tsfecg01apart1of3.rtf")
 })

--- a/tests/testthat/test-tsfecg01apart1.R
+++ b/tests/testthat/test-tsfecg01apart1.R
@@ -1,9 +1,5 @@
 test_that("tsfecg01a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfecg01a.R", part_num = 1, total_parts = 3), "tsfecg01apart1of3.rtf")
 })

--- a/tests/testthat/test-tsfecg01apart2.R
+++ b/tests/testthat/test-tsfecg01apart2.R
@@ -1,9 +1,5 @@
 test_that("tsfecg01a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfecg01a.R", part_num = 2, total_parts = 3), "tsfecg01apart2of3.rtf")
 })

--- a/tests/testthat/test-tsfecg01apart2.R
+++ b/tests/testthat/test-tsfecg01apart2.R
@@ -1,3 +1,9 @@
 test_that("tsfecg01a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfecg01a.R", part_num = 2, total_parts = 3), "tsfecg01apart2of3.rtf")
 })

--- a/tests/testthat/test-tsfecg01apart3.R
+++ b/tests/testthat/test-tsfecg01apart3.R
@@ -1,3 +1,9 @@
 test_that("tsfecg01a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfecg01a.R", part_num = 3, total_parts = 3), "tsfecg01apart3of3.rtf")
 })

--- a/tests/testthat/test-tsfecg01apart3.R
+++ b/tests/testthat/test-tsfecg01apart3.R
@@ -1,9 +1,5 @@
 test_that("tsfecg01a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfecg01a.R", part_num = 3, total_parts = 3), "tsfecg01apart3of3.rtf")
 })

--- a/tests/testthat/test-tsfecg01part1.R
+++ b/tests/testthat/test-tsfecg01part1.R
@@ -1,9 +1,5 @@
 test_that("tsfecg01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfecg01.R", part_num = 1, total_parts = 2), "tsfecg01part1of2.rtf")
 })

--- a/tests/testthat/test-tsfecg01part1.R
+++ b/tests/testthat/test-tsfecg01part1.R
@@ -1,3 +1,9 @@
 test_that("tsfecg01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfecg01.R", part_num = 1, total_parts = 2), "tsfecg01part1of2.rtf")
 })

--- a/tests/testthat/test-tsfecg01part2.R
+++ b/tests/testthat/test-tsfecg01part2.R
@@ -1,9 +1,5 @@
 test_that("tsfecg01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfecg01.R", part_num = 2, total_parts = 2), "tsfecg01part2of2.rtf")
 })

--- a/tests/testthat/test-tsfecg01part2.R
+++ b/tests/testthat/test-tsfecg01part2.R
@@ -1,3 +1,9 @@
 test_that("tsfecg01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfecg01.R", part_num = 2, total_parts = 2), "tsfecg01part2of2.rtf")
 })

--- a/tests/testthat/test-tsfecg02.R
+++ b/tests/testthat/test-tsfecg02.R
@@ -1,3 +1,9 @@
 test_that("tsfecg02", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfecg02.R"), "tsfecg02.rtf")
 })

--- a/tests/testthat/test-tsfecg02.R
+++ b/tests/testthat/test-tsfecg02.R
@@ -1,9 +1,5 @@
 test_that("tsfecg02", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfecg02.R"), "tsfecg02.rtf")
 })

--- a/tests/testthat/test-tsfecg03.R
+++ b/tests/testthat/test-tsfecg03.R
@@ -1,9 +1,5 @@
 test_that("tsfecg03", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfecg03.R"), "tsfecg03.rtf")
 })

--- a/tests/testthat/test-tsfecg03.R
+++ b/tests/testthat/test-tsfecg03.R
@@ -1,3 +1,9 @@
 test_that("tsfecg03", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfecg03.R"), "tsfecg03.rtf")
 })

--- a/tests/testthat/test-tsfecg04.R
+++ b/tests/testthat/test-tsfecg04.R
@@ -1,3 +1,9 @@
 test_that("tsfecg04", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfecg04.R"), "tsfecg04.rtf")
 })

--- a/tests/testthat/test-tsfecg04.R
+++ b/tests/testthat/test-tsfecg04.R
@@ -1,9 +1,5 @@
 test_that("tsfecg04", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfecg04.R"), "tsfecg04.rtf")
 })

--- a/tests/testthat/test-tsfecg05.R
+++ b/tests/testthat/test-tsfecg05.R
@@ -1,3 +1,9 @@
 test_that("tsfecg05", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfecg05.R"), "tsfecg05.rtf")
 })

--- a/tests/testthat/test-tsfecg05.R
+++ b/tests/testthat/test-tsfecg05.R
@@ -1,9 +1,5 @@
 test_that("tsfecg05", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfecg05.R"), "tsfecg05.rtf")
 })

--- a/tests/testthat/test-tsflab01apart1.R
+++ b/tests/testthat/test-tsflab01apart1.R
@@ -1,10 +1,6 @@
 test_that("tsflab01a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(
     write_test_rtf_for("tsflab01a.R", part_num = 1, total_parts = 3),
     "tsflab01apart1of3.rtf"

--- a/tests/testthat/test-tsflab01apart1.R
+++ b/tests/testthat/test-tsflab01apart1.R
@@ -1,4 +1,10 @@
 test_that("tsflab01a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(
     write_test_rtf_for("tsflab01a.R", part_num = 1, total_parts = 3),
     "tsflab01apart1of3.rtf"

--- a/tests/testthat/test-tsflab01apart2.R
+++ b/tests/testthat/test-tsflab01apart2.R
@@ -1,4 +1,10 @@
 test_that("tsflab01a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(
     write_test_rtf_for("tsflab01a.R", part_num = 2, total_parts = 3),
     "tsflab01apart2of3.rtf"

--- a/tests/testthat/test-tsflab01apart2.R
+++ b/tests/testthat/test-tsflab01apart2.R
@@ -1,10 +1,6 @@
 test_that("tsflab01a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(
     write_test_rtf_for("tsflab01a.R", part_num = 2, total_parts = 3),
     "tsflab01apart2of3.rtf"

--- a/tests/testthat/test-tsflab01apart3.R
+++ b/tests/testthat/test-tsflab01apart3.R
@@ -1,4 +1,10 @@
 test_that("tsflab01a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(
     write_test_rtf_for("tsflab01a.R", part_num = 3, total_parts = 3),
     "tsflab01apart3of3.rtf"

--- a/tests/testthat/test-tsflab01apart3.R
+++ b/tests/testthat/test-tsflab01apart3.R
@@ -1,10 +1,6 @@
 test_that("tsflab01a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(
     write_test_rtf_for("tsflab01a.R", part_num = 3, total_parts = 3),
     "tsflab01apart3of3.rtf"

--- a/tests/testthat/test-tsflab01part1.R
+++ b/tests/testthat/test-tsflab01part1.R
@@ -1,4 +1,10 @@
 test_that("tsflab01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(
     write_test_rtf_for("tsflab01.R", part_num = 1, total_parts = 2),
     "tsflab01part1of2.rtf"

--- a/tests/testthat/test-tsflab01part1.R
+++ b/tests/testthat/test-tsflab01part1.R
@@ -1,10 +1,6 @@
 test_that("tsflab01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(
     write_test_rtf_for("tsflab01.R", part_num = 1, total_parts = 2),
     "tsflab01part1of2.rtf"

--- a/tests/testthat/test-tsflab01part2.R
+++ b/tests/testthat/test-tsflab01part2.R
@@ -1,10 +1,6 @@
 test_that("tsflab01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(
     write_test_rtf_for("tsflab01.R", part_num = 2, total_parts = 2),
     "tsflab01part2of2.rtf"

--- a/tests/testthat/test-tsflab01part2.R
+++ b/tests/testthat/test-tsflab01part2.R
@@ -1,4 +1,10 @@
 test_that("tsflab01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(
     write_test_rtf_for("tsflab01.R", part_num = 2, total_parts = 2),
     "tsflab01part2of2.rtf"

--- a/tests/testthat/test-tsflab02.R
+++ b/tests/testthat/test-tsflab02.R
@@ -1,3 +1,9 @@
 test_that("tsflab02", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsflab02.R"), "tsflab02.rtf")
 })

--- a/tests/testthat/test-tsflab02.R
+++ b/tests/testthat/test-tsflab02.R
@@ -1,9 +1,5 @@
 test_that("tsflab02", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsflab02.R"), "tsflab02.rtf")
 })

--- a/tests/testthat/test-tsflab02a.R
+++ b/tests/testthat/test-tsflab02a.R
@@ -1,9 +1,5 @@
 test_that("tsflab02a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsflab02a.R"), "tsflab02a.rtf")
 })

--- a/tests/testthat/test-tsflab02a.R
+++ b/tests/testthat/test-tsflab02a.R
@@ -1,3 +1,9 @@
 test_that("tsflab02a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsflab02a.R"), "tsflab02a.rtf")
 })

--- a/tests/testthat/test-tsflab02b.R
+++ b/tests/testthat/test-tsflab02b.R
@@ -1,9 +1,5 @@
 test_that("tsflab02b", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsflab02b.R"), "tsflab02b.rtf")
 })

--- a/tests/testthat/test-tsflab02b.R
+++ b/tests/testthat/test-tsflab02b.R
@@ -1,3 +1,9 @@
 test_that("tsflab02b", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsflab02b.R"), "tsflab02b.rtf")
 })

--- a/tests/testthat/test-tsflab03.R
+++ b/tests/testthat/test-tsflab03.R
@@ -1,9 +1,5 @@
 test_that("tsflab03", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsflab03.R"), "tsflab03.rtf")
 })

--- a/tests/testthat/test-tsflab03.R
+++ b/tests/testthat/test-tsflab03.R
@@ -1,3 +1,9 @@
 test_that("tsflab03", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsflab03.R"), "tsflab03.rtf")
 })

--- a/tests/testthat/test-tsflab03a.R
+++ b/tests/testthat/test-tsflab03a.R
@@ -1,3 +1,9 @@
 test_that("tsflab03a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsflab03a.R"), "tsflab03a.rtf")
 })

--- a/tests/testthat/test-tsflab03a.R
+++ b/tests/testthat/test-tsflab03a.R
@@ -1,9 +1,5 @@
 test_that("tsflab03a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsflab03a.R"), "tsflab03a.rtf")
 })

--- a/tests/testthat/test-tsflab04a.R
+++ b/tests/testthat/test-tsflab04a.R
@@ -1,3 +1,9 @@
 test_that("tsflab04a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsflab04a.R"), "tsflab04a.rtf")
 })

--- a/tests/testthat/test-tsflab04a.R
+++ b/tests/testthat/test-tsflab04a.R
@@ -1,9 +1,5 @@
 test_that("tsflab04a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsflab04a.R"), "tsflab04a.rtf")
 })

--- a/tests/testthat/test-tsflab04b.R
+++ b/tests/testthat/test-tsflab04b.R
@@ -1,9 +1,5 @@
 test_that("tsflab04b", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsflab04b.R"), "tsflab04b.rtf")
 })

--- a/tests/testthat/test-tsflab04b.R
+++ b/tests/testthat/test-tsflab04b.R
@@ -1,3 +1,9 @@
 test_that("tsflab04b", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsflab04b.R"), "tsflab04b.rtf")
 })

--- a/tests/testthat/test-tsflab05.R
+++ b/tests/testthat/test-tsflab05.R
@@ -1,9 +1,5 @@
 test_that("tsflab05", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsflab05.R"), "tsflab05.rtf")
 })

--- a/tests/testthat/test-tsflab05.R
+++ b/tests/testthat/test-tsflab05.R
@@ -1,3 +1,9 @@
 test_that("tsflab05", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsflab05.R"), "tsflab05.rtf")
 })

--- a/tests/testthat/test-tsflab06.R
+++ b/tests/testthat/test-tsflab06.R
@@ -1,9 +1,5 @@
 test_that("tsflab06", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsflab06.R"), "tsflab06.rtf")
 })

--- a/tests/testthat/test-tsflab06.R
+++ b/tests/testthat/test-tsflab06.R
@@ -1,3 +1,9 @@
 test_that("tsflab06", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsflab06.R"), "tsflab06.rtf")
 })

--- a/tests/testthat/test-tsflab07.R
+++ b/tests/testthat/test-tsflab07.R
@@ -1,3 +1,9 @@
 test_that("tsflab07", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsflab07.R"), "tsflab07.rtf")
 })

--- a/tests/testthat/test-tsflab07.R
+++ b/tests/testthat/test-tsflab07.R
@@ -1,9 +1,5 @@
 test_that("tsflab07", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsflab07.R"), "tsflab07.rtf")
 })

--- a/tests/testthat/test-tsfvit01apart1.R
+++ b/tests/testthat/test-tsfvit01apart1.R
@@ -1,10 +1,6 @@
 test_that("tsfvit01a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(
     write_test_rtf_for("tsfvit01a.R", part_num = 1, total_parts = 4),
     "tsfvit01apart1of4.rtf"

--- a/tests/testthat/test-tsfvit01apart1.R
+++ b/tests/testthat/test-tsfvit01apart1.R
@@ -1,4 +1,10 @@
 test_that("tsfvit01a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(
     write_test_rtf_for("tsfvit01a.R", part_num = 1, total_parts = 4),
     "tsfvit01apart1of4.rtf"

--- a/tests/testthat/test-tsfvit01apart2.R
+++ b/tests/testthat/test-tsfvit01apart2.R
@@ -1,10 +1,6 @@
 test_that("tsfvit01a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(
     write_test_rtf_for("tsfvit01a.R", part_num = 2, total_parts = 4),
     "tsfvit01apart2of4.rtf"

--- a/tests/testthat/test-tsfvit01apart2.R
+++ b/tests/testthat/test-tsfvit01apart2.R
@@ -1,4 +1,10 @@
 test_that("tsfvit01a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(
     write_test_rtf_for("tsfvit01a.R", part_num = 2, total_parts = 4),
     "tsfvit01apart2of4.rtf"

--- a/tests/testthat/test-tsfvit01apart3.R
+++ b/tests/testthat/test-tsfvit01apart3.R
@@ -1,10 +1,6 @@
 test_that("tsfvit01a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(
     write_test_rtf_for("tsfvit01a.R", part_num = 3, total_parts = 4),
     "tsfvit01apart3of4.rtf"

--- a/tests/testthat/test-tsfvit01apart3.R
+++ b/tests/testthat/test-tsfvit01apart3.R
@@ -1,4 +1,10 @@
 test_that("tsfvit01a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(
     write_test_rtf_for("tsfvit01a.R", part_num = 3, total_parts = 4),
     "tsfvit01apart3of4.rtf"

--- a/tests/testthat/test-tsfvit01apart4.R
+++ b/tests/testthat/test-tsfvit01apart4.R
@@ -1,10 +1,6 @@
 test_that("tsfvit01a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(
     write_test_rtf_for("tsfvit01a.R", part_num = 4, total_parts = 4),
     "tsfvit01apart4of4.rtf"

--- a/tests/testthat/test-tsfvit01apart4.R
+++ b/tests/testthat/test-tsfvit01apart4.R
@@ -1,4 +1,10 @@
 test_that("tsfvit01a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(
     write_test_rtf_for("tsfvit01a.R", part_num = 4, total_parts = 4),
     "tsfvit01apart4of4.rtf"

--- a/tests/testthat/test-tsfvit01part1.R
+++ b/tests/testthat/test-tsfvit01part1.R
@@ -1,10 +1,6 @@
 test_that("tsfvit01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(
     write_test_rtf_for("tsfvit01.R", part_num = 1, total_parts = 4),
     "tsfvit01part1of4.rtf"

--- a/tests/testthat/test-tsfvit01part1.R
+++ b/tests/testthat/test-tsfvit01part1.R
@@ -1,4 +1,10 @@
 test_that("tsfvit01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(
     write_test_rtf_for("tsfvit01.R", part_num = 1, total_parts = 4),
     "tsfvit01part1of4.rtf"

--- a/tests/testthat/test-tsfvit01part2.R
+++ b/tests/testthat/test-tsfvit01part2.R
@@ -1,4 +1,10 @@
 test_that("tsfvit01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(
     write_test_rtf_for("tsfvit01.R", part_num = 2, total_parts = 4),
     "tsfvit01part2of4.rtf"

--- a/tests/testthat/test-tsfvit01part2.R
+++ b/tests/testthat/test-tsfvit01part2.R
@@ -1,10 +1,6 @@
 test_that("tsfvit01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(
     write_test_rtf_for("tsfvit01.R", part_num = 2, total_parts = 4),
     "tsfvit01part2of4.rtf"

--- a/tests/testthat/test-tsfvit01part3.R
+++ b/tests/testthat/test-tsfvit01part3.R
@@ -1,4 +1,10 @@
 test_that("tsfvit01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(
     write_test_rtf_for("tsfvit01.R", part_num = 3, total_parts = 4),
     "tsfvit01part3of4.rtf"

--- a/tests/testthat/test-tsfvit01part3.R
+++ b/tests/testthat/test-tsfvit01part3.R
@@ -1,10 +1,6 @@
 test_that("tsfvit01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(
     write_test_rtf_for("tsfvit01.R", part_num = 3, total_parts = 4),
     "tsfvit01part3of4.rtf"

--- a/tests/testthat/test-tsfvit01part4.R
+++ b/tests/testthat/test-tsfvit01part4.R
@@ -1,10 +1,6 @@
 test_that("tsfvit01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(
     write_test_rtf_for("tsfvit01.R", part_num = 4, total_parts = 4),
     "tsfvit01part4of4.rtf"

--- a/tests/testthat/test-tsfvit01part4.R
+++ b/tests/testthat/test-tsfvit01part4.R
@@ -1,4 +1,10 @@
 test_that("tsfvit01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(
     write_test_rtf_for("tsfvit01.R", part_num = 4, total_parts = 4),
     "tsfvit01part4of4.rtf"

--- a/tests/testthat/test-tsfvit02.R
+++ b/tests/testthat/test-tsfvit02.R
@@ -1,3 +1,9 @@
 test_that("tsfvit02", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfvit02.R"), "tsfvit02.rtf")
 })

--- a/tests/testthat/test-tsfvit02.R
+++ b/tests/testthat/test-tsfvit02.R
@@ -1,9 +1,5 @@
 test_that("tsfvit02", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfvit02.R"), "tsfvit02.rtf")
 })

--- a/tests/testthat/test-tsfvit03.R
+++ b/tests/testthat/test-tsfvit03.R
@@ -1,3 +1,9 @@
 test_that("tsfvit03", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfvit03.R"), "tsfvit03.rtf")
 })

--- a/tests/testthat/test-tsfvit03.R
+++ b/tests/testthat/test-tsfvit03.R
@@ -1,9 +1,5 @@
 test_that("tsfvit03", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfvit03.R"), "tsfvit03.rtf")
 })

--- a/tests/testthat/test-tsfvit04.R
+++ b/tests/testthat/test-tsfvit04.R
@@ -1,3 +1,9 @@
 test_that("tsfvit04", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfvit04.R"), "tsfvit04.rtf")
 })

--- a/tests/testthat/test-tsfvit04.R
+++ b/tests/testthat/test-tsfvit04.R
@@ -1,9 +1,5 @@
 test_that("tsfvit04", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfvit04.R"), "tsfvit04.rtf")
 })

--- a/tests/testthat/test-tsfvit05.R
+++ b/tests/testthat/test-tsfvit05.R
@@ -1,9 +1,5 @@
 test_that("tsfvit05", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfvit05.R"), "tsfvit05.rtf")
 })

--- a/tests/testthat/test-tsfvit05.R
+++ b/tests/testthat/test-tsfvit05.R
@@ -1,3 +1,9 @@
 test_that("tsfvit05", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfvit05.R"), "tsfvit05.rtf")
 })

--- a/tests/testthat/test-tsfvit06.R
+++ b/tests/testthat/test-tsfvit06.R
@@ -1,9 +1,5 @@
 test_that("tsfvit06", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsfvit06.R"), "tsfvit06.rtf")
 })

--- a/tests/testthat/test-tsfvit06.R
+++ b/tests/testthat/test-tsfvit06.R
@@ -1,3 +1,9 @@
 test_that("tsfvit06", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsfvit06.R"), "tsfvit06.rtf")
 })

--- a/tests/testthat/test-tsicm01.R
+++ b/tests/testthat/test-tsicm01.R
@@ -1,9 +1,5 @@
 test_that("tsicm01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsicm01.R"), "tsicm01.rtf")
 })

--- a/tests/testthat/test-tsicm01.R
+++ b/tests/testthat/test-tsicm01.R
@@ -1,3 +1,9 @@
 test_that("tsicm01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsicm01.R"), "tsicm01.rtf")
 })

--- a/tests/testthat/test-tsicm02.R
+++ b/tests/testthat/test-tsicm02.R
@@ -1,9 +1,5 @@
 test_that("tsicm02", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsicm02.R"), "tsicm02.rtf")
 })

--- a/tests/testthat/test-tsicm02.R
+++ b/tests/testthat/test-tsicm02.R
@@ -1,3 +1,9 @@
 test_that("tsicm02", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsicm02.R"), "tsicm02.rtf")
 })

--- a/tests/testthat/test-tsicm03.R
+++ b/tests/testthat/test-tsicm03.R
@@ -1,3 +1,9 @@
 test_that("tsicm03", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsicm03.R"), "tsicm03.rtf")
 })

--- a/tests/testthat/test-tsicm03.R
+++ b/tests/testthat/test-tsicm03.R
@@ -1,9 +1,5 @@
 test_that("tsicm03", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsicm03.R"), "tsicm03.rtf")
 })

--- a/tests/testthat/test-tsicm04.R
+++ b/tests/testthat/test-tsicm04.R
@@ -1,9 +1,5 @@
 test_that("tsicm04", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsicm04.R"), "tsicm04.rtf")
 })

--- a/tests/testthat/test-tsicm04.R
+++ b/tests/testthat/test-tsicm04.R
@@ -1,3 +1,9 @@
 test_that("tsicm04", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsicm04.R"), "tsicm04.rtf")
 })

--- a/tests/testthat/test-tsicm05.R
+++ b/tests/testthat/test-tsicm05.R
@@ -1,3 +1,9 @@
 test_that("tsicm05", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsicm05.R"), "tsicm05.rtf")
 })

--- a/tests/testthat/test-tsicm05.R
+++ b/tests/testthat/test-tsicm05.R
@@ -1,9 +1,5 @@
 test_that("tsicm05", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsicm05.R"), "tsicm05.rtf")
 })

--- a/tests/testthat/test-tsicm06.R
+++ b/tests/testthat/test-tsicm06.R
@@ -1,3 +1,9 @@
 test_that("tsicm06", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsicm06.R"), "tsicm06.rtf")
 })

--- a/tests/testthat/test-tsicm06.R
+++ b/tests/testthat/test-tsicm06.R
@@ -1,9 +1,5 @@
 test_that("tsicm06", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsicm06.R"), "tsicm06.rtf")
 })

--- a/tests/testthat/test-tsicm07.R
+++ b/tests/testthat/test-tsicm07.R
@@ -1,3 +1,9 @@
 test_that("tsicm07", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsicm07.R"), "tsicm07.rtf")
 })

--- a/tests/testthat/test-tsicm07.R
+++ b/tests/testthat/test-tsicm07.R
@@ -1,9 +1,5 @@
 test_that("tsicm07", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsicm07.R"), "tsicm07.rtf")
 })

--- a/tests/testthat/test-tsicm08.R
+++ b/tests/testthat/test-tsicm08.R
@@ -1,3 +1,9 @@
 test_that("tsicm08", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsicm08.R"), "tsicm08.rtf")
 })

--- a/tests/testthat/test-tsicm08.R
+++ b/tests/testthat/test-tsicm08.R
@@ -1,9 +1,5 @@
 test_that("tsicm08", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsicm08.R"), "tsicm08.rtf")
 })

--- a/tests/testthat/test-tsidem01.R
+++ b/tests/testthat/test-tsidem01.R
@@ -1,9 +1,5 @@
 test_that("tsidem01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsidem01.R"), "tsidem01.rtf")
 })

--- a/tests/testthat/test-tsidem01.R
+++ b/tests/testthat/test-tsidem01.R
@@ -1,3 +1,9 @@
 test_that("tsidem01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsidem01.R"), "tsidem01.rtf")
 })

--- a/tests/testthat/test-tsidem02.R
+++ b/tests/testthat/test-tsidem02.R
@@ -1,3 +1,9 @@
 test_that("tsidem02", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsidem02.R"), "tsidem02.rtf")
 })

--- a/tests/testthat/test-tsidem02.R
+++ b/tests/testthat/test-tsidem02.R
@@ -1,9 +1,5 @@
 test_that("tsidem02", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsidem02.R"), "tsidem02.rtf")
 })

--- a/tests/testthat/test-tsids01.R
+++ b/tests/testthat/test-tsids01.R
@@ -1,3 +1,9 @@
 test_that("tsids01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsids01.R"), "tsids01.rtf")
 })

--- a/tests/testthat/test-tsids01.R
+++ b/tests/testthat/test-tsids01.R
@@ -1,9 +1,5 @@
 test_that("tsids01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsids01.R"), "tsids01.rtf")
 })

--- a/tests/testthat/test-tsids02.R
+++ b/tests/testthat/test-tsids02.R
@@ -1,9 +1,5 @@
 test_that("tsids02", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsids02.R"), "tsids02.rtf")
 })

--- a/tests/testthat/test-tsids02.R
+++ b/tests/testthat/test-tsids02.R
@@ -1,3 +1,9 @@
 test_that("tsids02", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsids02.R"), "tsids02.rtf")
 })

--- a/tests/testthat/test-tsids02a.R
+++ b/tests/testthat/test-tsids02a.R
@@ -1,9 +1,5 @@
 test_that("tsids02a", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsids02a.R"), "tsids02a.rtf")
 })

--- a/tests/testthat/test-tsids02a.R
+++ b/tests/testthat/test-tsids02a.R
@@ -1,3 +1,9 @@
 test_that("tsids02a", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsids02a.R"), "tsids02a.rtf")
 })

--- a/tests/testthat/test-tsiex01.R
+++ b/tests/testthat/test-tsiex01.R
@@ -1,9 +1,5 @@
 test_that("tsiex01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsiex01.R"), "tsiex01.rtf")
 })

--- a/tests/testthat/test-tsiex01.R
+++ b/tests/testthat/test-tsiex01.R
@@ -1,3 +1,9 @@
 test_that("tsiex01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsiex01.R"), "tsiex01.rtf")
 })

--- a/tests/testthat/test-tsiex02.R
+++ b/tests/testthat/test-tsiex02.R
@@ -1,3 +1,9 @@
 test_that("tsiex02", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsiex02.R"), "tsiex02.rtf")
 })

--- a/tests/testthat/test-tsiex02.R
+++ b/tests/testthat/test-tsiex02.R
@@ -1,9 +1,5 @@
 test_that("tsiex02", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsiex02.R"), "tsiex02.rtf")
 })

--- a/tests/testthat/test-tsiex03.R
+++ b/tests/testthat/test-tsiex03.R
@@ -1,3 +1,9 @@
 test_that("tsiex03", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsiex03.R"), "tsiex03.rtf")
 })

--- a/tests/testthat/test-tsiex03.R
+++ b/tests/testthat/test-tsiex03.R
@@ -1,9 +1,5 @@
 test_that("tsiex03", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsiex03.R"), "tsiex03.rtf")
 })

--- a/tests/testthat/test-tsiex04.R
+++ b/tests/testthat/test-tsiex04.R
@@ -1,9 +1,5 @@
 test_that("tsiex04", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsiex04.R"), "tsiex04.rtf")
 })

--- a/tests/testthat/test-tsiex04.R
+++ b/tests/testthat/test-tsiex04.R
@@ -1,3 +1,9 @@
 test_that("tsiex04", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsiex04.R"), "tsiex04.rtf")
 })

--- a/tests/testthat/test-tsiex06.R
+++ b/tests/testthat/test-tsiex06.R
@@ -1,9 +1,5 @@
 test_that("tsiex06", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsiex06.R"), "tsiex06.rtf")
 })

--- a/tests/testthat/test-tsiex06.R
+++ b/tests/testthat/test-tsiex06.R
@@ -1,3 +1,9 @@
 test_that("tsiex06", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsiex06.R"), "tsiex06.rtf")
 })

--- a/tests/testthat/test-tsiex07.R
+++ b/tests/testthat/test-tsiex07.R
@@ -1,3 +1,9 @@
 test_that("tsiex07", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsiex07.R"), "tsiex07.rtf")
 })

--- a/tests/testthat/test-tsiex07.R
+++ b/tests/testthat/test-tsiex07.R
@@ -1,9 +1,5 @@
 test_that("tsiex07", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsiex07.R"), "tsiex07.rtf")
 })

--- a/tests/testthat/test-tsiex08.R
+++ b/tests/testthat/test-tsiex08.R
@@ -1,9 +1,5 @@
 test_that("tsiex08", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsiex08.R"), "tsiex08.rtf")
 })

--- a/tests/testthat/test-tsiex08.R
+++ b/tests/testthat/test-tsiex08.R
@@ -1,3 +1,9 @@
 test_that("tsiex08", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsiex08.R"), "tsiex08.rtf")
 })

--- a/tests/testthat/test-tsiex09.R
+++ b/tests/testthat/test-tsiex09.R
@@ -1,9 +1,5 @@
 test_that("tsiex09", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsiex09.R"), "tsiex09.rtf")
 })

--- a/tests/testthat/test-tsiex09.R
+++ b/tests/testthat/test-tsiex09.R
@@ -1,3 +1,9 @@
 test_that("tsiex09", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsiex09.R"), "tsiex09.rtf")
 })

--- a/tests/testthat/test-tsiex10.R
+++ b/tests/testthat/test-tsiex10.R
@@ -1,3 +1,9 @@
 test_that("tsiex10", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsiex10.R"), "tsiex10.rtf")
 })

--- a/tests/testthat/test-tsiex10.R
+++ b/tests/testthat/test-tsiex10.R
@@ -1,9 +1,5 @@
 test_that("tsiex10", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsiex10.R"), "tsiex10.rtf")
 })

--- a/tests/testthat/test-tsiex11.R
+++ b/tests/testthat/test-tsiex11.R
@@ -1,9 +1,5 @@
 test_that("tsiex11", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsiex11.R"), "tsiex11.rtf")
 })

--- a/tests/testthat/test-tsiex11.R
+++ b/tests/testthat/test-tsiex11.R
@@ -1,3 +1,9 @@
 test_that("tsiex11", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsiex11.R"), "tsiex11.rtf")
 })

--- a/tests/testthat/test-tsimh01.R
+++ b/tests/testthat/test-tsimh01.R
@@ -1,9 +1,5 @@
 test_that("tsimh01", {
   skip_if_not_installed("envsetup")
-  skip_if_not_installed("tern")
-  skip_if_not_installed("dplyr")
-  skip_if_not_installed("rtables")
-  skip_if_not_installed("rlistings")
-  skip_if_not_installed("stringi")
+
   expect_snapshot_file(write_test_rtf_for("tsimh01.R"), "tsimh01.rtf")
 })

--- a/tests/testthat/test-tsimh01.R
+++ b/tests/testthat/test-tsimh01.R
@@ -1,3 +1,9 @@
 test_that("tsimh01", {
+  skip_if_not_installed("envsetup")
+  skip_if_not_installed("tern")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("rtables")
+  skip_if_not_installed("rlistings")
+  skip_if_not_installed("stringi")
   expect_snapshot_file(write_test_rtf_for("tsimh01.R"), "tsimh01.rtf")
 })


### PR DESCRIPTION
Skip test if suggested packages are not present on the tests running the templates. 
Close #288

I've added the most common ones on the tests but some might not be needed to run the template. 
The script I generated to check which ones are needed cannot be run on my local computer (memory problems probably). 

There is one "hidden" call to setupenv on helpers.R (Line 11)  but shown on tests I don't think it makes it fail.
There are other packages on Suggests called on setup*.R scripts, but I haven't addressed them 

<details><summary>Script</summary>
<p>

```r
text <- c(
  "test-lsfae01.R", "lsfae01.R",
  "test-lsfae02.R", "lsfae02.R",
  "test-lsfae03.R", "lsfae03.R",
  "test-lsfae04.R", "lsfae04.R",
  "test-lsfae05.R", "lsfae05.R",
  "test-lsfae06a.R", "lsfae06a.R",
  "test-lsfae06b.R", "lsfae06b.R",
  "test-lsfdth01.R", "lsfdth01.R",
  "test-lsfecg01.R", "lsfecg01.R",
  "test-lsfecg02part1.R", "lsfecg02.R",
  "test-lsfecg02part2.R", "lsfecg02.R",
  "test-lsfecg02part3.R", "lsfecg02.R",
  "test-lsflab01.R", "lsflab01.R",
  "test-lsfvit01.R", "lsfvit01.R",
  "test-lsfvit02.R", "lsfvit02.R",
  "test-lsicm01.R", "lsicm01.R",
  "test-lsidem01.R", "lsidem01.R",
  "test-lsidem02.R", "lsidem02.R",
  "test-lsids01.R", "lsids01.R",
  "test-lsids02.R", "lsids02.R",
  "test-lsids03.R", "lsids03.R",
  "test-lsids04.R", "lsids04.R",
  "test-lsids05.R", "lsids05.R",
  "test-lsiex01.R", "lsiex01.R",
  "test-lsiex02.R", "lsiex02.R",
  "test-lsiex03.R", "lsiex03.R",
  "test-lsimh01.R", "lsimh01.R",
  "test-tpk01a.R", "tpk01a.R",
  "test-tpk01bpart1.R", "tpk01b.R",
  "test-tpk01bpart2.R", "tpk01b.R",
  "test-tpk02part1.R", "tpk02.R",
  "test-tpk02part2.R", "tpk02.R",
  "test-tpk03.R", "tpk03.R",
  "test-tsfae01a.R", "tsfae01a.R",
  "test-tsfae01b.R", "tsfae01b.R",
  "test-tsfae02.R", "tsfae02.R",
  "test-tsfae02a.R", "tsfae02a.R",
  "test-tsfae03.R", "tsfae03.R",
  "test-tsfae03a.R", "tsfae03a.R",
  "test-tsfae04.R", "tsfae04.R",
  "test-tsfae04a.R", "tsfae04a.R",
  "test-tsfae05.R", "tsfae05.R",
  "test-tsfae05a.R", "tsfae05a.R",
  "test-tsfae06a.R", "tsfae06a.R",
  "test-tsfae06b.R", "tsfae06b.R",
  "test-tsfae07a.R", "tsfae07a.R",
  "test-tsfae07b.R", "tsfae07b.R",
  "test-tsfae08.R", "tsfae08.R",
  "test-tsfae09.R", "tsfae09.R",
  "test-tsfae10.R", "tsfae10.R",
  "test-tsfae11.R", "tsfae11.R",
  "test-tsfae12.R", "tsfae12.R",
  "test-tsfae13.R", "tsfae13.R",
  "test-tsfae14.R", "tsfae14.R",
  "test-tsfae15.R", "tsfae15.R",
  "test-tsfae16part1.R", "tsfae16.R",
  "test-tsfae16part2.R", "tsfae16.R",
  "test-tsfae17a.R", "tsfae17a.R",
  "test-tsfae17b.R", "tsfae17b.R",
  "test-tsfae17c.R", "tsfae17c.R",
  "test-tsfae17d.R", "tsfae17d.R",
  "test-tsfae19a.R", "tsfae19a.R",
  "test-tsfae19b.R", "tsfae19b.R",
  "test-tsfae19c.R", "tsfae19c.R",
  "test-tsfae19d.R", "tsfae19d.R",
  "test-tsfae20a.R", "tsfae20a.R",
  "test-tsfae20b.R", "tsfae20b.R",
  "test-tsfae20c.R", "tsfae20c.R",
  "test-tsfae21apart1.R", "tsfae21a.R",
  "test-tsfae21apart2.R", "tsfae21a.R",
  "test-tsfae21apart3.R", "tsfae21a.R",
  "test-tsfae21apart4.R", "tsfae21a.R",
  "test-tsfae21bpart1.R", "tsfae21b.R",
  "test-tsfae21bpart2.R", "tsfae21b.R",
  "test-tsfae21bpart3.R", "tsfae21b.R",
  "test-tsfae21bpart4.R", "tsfae21b.R",
  "test-tsfae21c.R", "tsfae21c.R",
  "test-tsfae21d.R", "tsfae21d.R",
  "test-tsfae22apart1.R", "tsfae22a.R",
  "test-tsfae22apart2.R", "tsfae22a.R",
  "test-tsfae22apart3.R", "tsfae22a.R",
  "test-tsfae22apart4.R", "tsfae22a.R",
  "test-tsfae22bpart1.R", "tsfae22b.R",
  "test-tsfae22bpart2.R", "tsfae22b.R",
  "test-tsfae22cpart1.R", "tsfae22c.R",
  "test-tsfae22cpart2.R", "tsfae22c.R",
  "test-tsfae22cpart3.R", "tsfae22c.R",
  "test-tsfae22cpart4.R", "tsfae22c.R",
  "test-tsfae23a.R", "tsfae23a.R",
  "test-tsfae23b.R", "tsfae23b.R",
  "test-tsfae23c.R", "tsfae23c.R",
  "test-tsfae23d.R", "tsfae23d.R",
  "test-tsfae24a.R", "tsfae24a.R",
  "test-tsfae24b.R", "tsfae24b.R",
  "test-tsfae24c.R", "tsfae24c.R",
  "test-tsfae24d.R", "tsfae24d.R",
  "test-tsfae24fpart1.R", "tsfae24f.R",
  "test-tsfae24fpart2.R", "tsfae24f.R",
  "test-tsfae24fpart3.R", "tsfae24f.R",
  "test-tsfdth01.R", "tsfdth01.R",
  "test-tsfecg01apart1.R", "tsfecg01a.R",
  "test-tsfecg01apart2.R", "tsfecg01a.R",
  "test-tsfecg01apart3.R", "tsfecg01a.R",
  "test-tsfecg01part1.R", "tsfecg01.R",
  "test-tsfecg01part2.R", "tsfecg01.R",
  "test-tsfecg02.R", "tsfecg02.R",
  "test-tsfecg03.R", "tsfecg03.R",
  "test-tsfecg04.R", "tsfecg04.R",
  "test-tsfecg05.R", "tsfecg05.R",
  "test-tsflab01apart1.R", "tsflab01a.R",
  "test-tsflab01apart2.R", "tsflab01a.R",
  "test-tsflab01apart3.R", "tsflab01a.R",
  "test-tsflab01part1.R", "tsflab01.R",
  "test-tsflab01part2.R", "tsflab01.R",
  "test-tsflab02.R", "tsflab02.R",
  "test-tsflab02a.R", "tsflab02a.R",
  "test-tsflab02b.R", "tsflab02b.R",
  "test-tsflab03.R", "tsflab03.R",
  "test-tsflab03a.R", "tsflab03a.R",
  "test-tsflab04a.R", "tsflab04a.R",
  "test-tsflab04b.R", "tsflab04b.R",
  "test-tsflab05.R", "tsflab05.R",
  "test-tsflab06.R", "tsflab06.R",
  "test-tsflab07.R", "tsflab07.R",
  "test-tsfvit01apart1.R", "tsfvit01a.R",
  "test-tsfvit01apart2.R", "tsfvit01a.R",
  "test-tsfvit01apart3.R", "tsfvit01a.R",
  "test-tsfvit01apart4.R", "tsfvit01a.R",
  "test-tsfvit01part1.R", "tsfvit01.R",
  "test-tsfvit01part2.R", "tsfvit01.R",
  "test-tsfvit01part3.R", "tsfvit01.R",
  "test-tsfvit01part4.R", "tsfvit01.R",
  "test-tsfvit02.R", "tsfvit02.R",
  "test-tsfvit03.R", "tsfvit03.R",
  "test-tsfvit04.R", "tsfvit04.R",
  "test-tsfvit05.R", "tsfvit05.R",
  "test-tsfvit06.R", "tsfvit06.R",
  "test-tsicm01.R", "tsicm01.R",
  "test-tsicm02.R", "tsicm02.R",
  "test-tsicm03.R", "tsicm03.R",
  "test-tsicm04.R", "tsicm04.R",
  "test-tsicm05.R", "tsicm05.R",
  "test-tsicm06.R", "tsicm06.R",
  "test-tsicm07.R", "tsicm07.R",
  "test-tsicm08.R", "tsicm08.R",
  "test-tsidem01.R", "tsidem01.R",
  "test-tsidem02.R", "tsidem02.R",
  "test-tsids01.R", "tsids01.R",
  "test-tsids02.R", "tsids02.R",
  "test-tsids02a.R", "tsids02a.R",
  "test-tsiex01.R", "tsiex01.R",
  "test-tsiex02.R", "tsiex02.R",
  "test-tsiex03.R", "tsiex03.R",
  "test-tsiex04.R", "tsiex04.R",
  "test-tsiex06.R", "tsiex06.R",
  "test-tsiex07.R", "tsiex07.R",
  "test-tsiex08.R", "tsiex08.R",
  "test-tsiex09.R", "tsiex09.R",
  "test-tsiex10.R", "tsiex10.R",
  "test-tsiex11.R", "tsiex11.R",
  "test-tsimh01.R", "tsimh01.R"
)

m <- matrix(text, ncol = 2, nrow = 161, byrow = TRUE)
colnames(m) <- c("test", "source")
d <- desc::desc()
pkgs_sugg <- desc::dep_types
check_pkgs <- function(x){
  test_file <- file.path("tests/testthat", x["test"])
  source_file <- file.path("tests/testthat/source_code", x["source"])
  test_pkgs <- system2("grep", args = c("skip_if_not_installed", test_file), stdout = TRUE)
  source_pkgs <- system2("grep", args = c("library", source_file), stdout = TRUE)
  
  test_pkgs <- gsub("skip_if_not_installed", "", trimws(test_pkgs))
  test_pkgs <- gsub('\\("', "", test_pkgs)
  test_pkgs <- gsub('\\")', "", test_pkgs)
  
  source_pkgs <- gsub("library", "", source_pkgs)
  source_pkgs <- gsub("\\(", "", source_pkgs)
  source_pkgs <- gsub("\\)", "", source_pkgs)
  
  i_pkgs <- intersect(test_pkgs, source_pkgs)
  setequal(i_pkgs, test_pkgs) && setequal(i_pkgs, source_pkgs)
}

k <- apply(m, 1, check_pkgs)
```

</p>
</details> 