### PR TITLE
Update junco to 0.1.6 release version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ Remotes:
     insightsengineering/rlistings@main,
     insightsengineering/rtables@main,
     insightsengineering/tern@main,
-    johnsonandjohnson/junco@patch-release-updated-rtf-snapshots,
+    johnsonandjohnson/junco@dev,
     johnsonandjohnson/pharmaverseadamjnj@main,
     johnsonandjohnson/pharmaversesdtmjnj@main,
     pharmaverse/pharmaverseadam@main

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ URL: https://github.com/insightsengineering/scda.test/
 BugReports: https://github.com/insightsengineering/scda.test/issues
 Depends:
     formatters (>= 0.5.12),
-    junco (>= 0.1.5),
+    junco (>= 0.1.6),
     R (>= 4.2),
     rlistings (>= 0.2.13),
     rtables (>= 0.6.15),


### PR DESCRIPTION
We are prepping the release of junco 0.1.6 so reruning tje pipelines to make sure everything is sound in terms of templates snapshots